### PR TITLE
Fixed issue #3

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,8 @@ int main(int argc, char** argv) {
 	if (outputFileName == "(auto)") {
 		outputFileName = cmdInputFile.getValue();
 		int tailDot = outputFileName.find_last_of('.');
-		outputFileName.erase(tailDot, outputFileName.length());
+		if(tailDot != std::string::npos)
+			outputFileName.erase(tailDot, outputFileName.length());
 		outputFileName = outputFileName + "(" + cmdMode.getValue() + ")";
 		std::string &mode = cmdMode.getValue();
 		if(mode.find("noise") != mode.npos){
@@ -168,6 +169,8 @@ int main(int argc, char** argv) {
 		}
 		outputFileName += ".png";
 	}
+	else if (outputFileName.find_last_of('.') == std::string::npos)
+		outputFileName += ".png";
 
 	enum W2XConvGPUMode gpu = W2XCONV_GPU_AUTO;
 


### PR DESCRIPTION
Yes now converter can use image without extension. output file extension will be .png if no extension of output has been set.