### PR TITLE
added OSX-specific clause to support different stat structure

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -200,12 +200,18 @@ update_test(const char *dst_path,
 
 	struct stat src_st;
 	stat(src_path, &src_st);
-
-	if (src_st.st_mtim.tv_sec > dst_st.st_mtim.tv_sec) {
+#ifdef __APPLE__
+	if (src_st.st_mtimespec.tv_sec > dst_st.st_mtimespec.tv_sec) {
+#else
+        if (src_st.st_mtim.tv_sec > dst_st.st_mtim.tv_sec) {
+#endif  /* __APPLE __ */
 		return true;
 	}
-
-	if (src_st.st_mtim.tv_nsec > dst_st.st_mtim.tv_nsec) {
+#ifdef __APPLE__
+	if (src_st.st_mtimespec.tv_nsec > dst_st.st_mtimespec.tv_nsec) {
+#else
+        if(src_st.st_mtim.tv_nsec > dst_st.st_mtim.tv_nsec) {
+#endif
 		return true;
 	}
 


### PR DESCRIPTION
OSX uses a different structure in its `stat` library, so I brutally IFDEF'ed  it in. Values should be the same, they just have different names. 

This works fine on OSX Sierra 10.12.6, but I expect it will be the same on 10.10+ and possibly even lower. This seems to be the only change necessary.