### PR TITLE
Add verbose cmdarg

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,9 +185,7 @@ int main(int argc, char** argv) {
 			0, "bool", cmd);
 
 
-	TCLAP::ValueArg<bool> cmdVerbose("v", "verbose",
-			"Enable verbose mode.", false,
-			true, "bool", cmd);
+	TCLAP::SwitchArg cmdQuiet("q", "quiet", "Enable quiet mode.", cmd, false);
 
 	std::vector<std::string> cmdModeConstraintV;
 	cmdModeConstraintV.push_back("noise");
@@ -266,7 +264,7 @@ int main(int argc, char** argv) {
 	int num_proc;
 	w2xconv_get_processor_list(&num_proc);
 	int proc = cmdTargetProcessor.getValue();
-	bool verbose = cmdVerbose.getValue();
+	bool verbose = !cmdQuiet.getValue();
 
 	if (proc != -1 && proc < num_proc) {
 		converter = w2xconv_init_with_processor(proc, cmdNumberOfJobs.getValue(), verbose);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
 
 	TCLAP::ValueArg<bool> cmdVerbose("v", "verbose",
 			"Enable verbose mode.", false,
-			0, "bool", cmd);
+			true, "bool", cmd);
 
 	std::vector<std::string> cmdModeConstraintV;
 	cmdModeConstraintV.push_back("noise");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,10 @@ int main(int argc, char** argv) {
 			0, "bool", cmd);
 
 
+	TCLAP::ValueArg<bool> cmdVerbose("v", "verbose",
+			"Enable verbose mode.", false,
+			0, "bool", cmd);
+
 	std::vector<std::string> cmdModeConstraintV;
 	cmdModeConstraintV.push_back("noise");
 	cmdModeConstraintV.push_back("scale");
@@ -262,14 +266,12 @@ int main(int argc, char** argv) {
 	int num_proc;
 	w2xconv_get_processor_list(&num_proc);
 	int proc = cmdTargetProcessor.getValue();
+	bool verbose = cmdVerbose.getValue();
 
 	if (proc != -1 && proc < num_proc) {
-		converter = w2xconv_init_with_processor(proc,
-							cmdNumberOfJobs.getValue(),
-							1);
+		converter = w2xconv_init_with_processor(proc, cmdNumberOfJobs.getValue(), verbose);
 	} else {
-		converter = w2xconv_init(gpu,
-					 cmdNumberOfJobs.getValue(), 1);
+		converter = w2xconv_init(gpu, cmdNumberOfJobs.getValue(), verbose);
 	}
 
 	double time_start = getsec();
@@ -337,6 +339,7 @@ int main(int argc, char** argv) {
 	}else{
 		numFilesProcessed++;
 		try{
+			std::cout << "Operating on: " << fs::absolute(input) << std::endl;
 			std::string outputName = generate_output_location(input, output, cmdMode.getValue(), cmdNRLevel.getValue(), cmdScaleRatio.getValue());
 			convert_file(input, outputName, cmdMode.getValue(), cmdNRLevel.getValue(), cmdScaleRatio.getValue(), blockSize, converter);
 		}catch(const std::exception& e){


### PR DESCRIPTION
This removes all console spam, one downside is that you don't know if the program locked up when there is a need to process a large file. (I've never had the program lock up)

This change does not add a pretty output method of the previously outputted spam.