### PR TITLE
CMake rework and Linux CL binary fix

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -170,7 +170,7 @@ Now lets build waifu2x-converter-cpp:
 ```
 $ git clone https://github.com/DeadSix27/waifu2x-converter-cpp && cd waifu2x-converter-cpp
 $ mkdir release && cd release 
-$ cmake .. -DOPENCV_PREFIX=/usr/local
+$ cmake ..
 $ make -j4
 $ cp ../models_rgb/ . -r
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,57 +4,67 @@ project(waifu2xcpp)
 include("CMakeDependentOption")
 include("CheckIncludeFileCXX")
 
-CMAKE_DEPENDENT_OPTION(FORCE_AMD "Whether to force detection of AMDSDK" OFF "NOT FORCE_CUDA" OFF) # When you have CUDASDK and AMDSDK installed but want to detect AMD primarly, set this ON
-CMAKE_DEPENDENT_OPTION(FORCE_CUDA "Whether to force detection of CUDASDK" OFF "NOT FORCE_AMD" OFF) # When you have CUDASDK and AMDSDK installed but want to detect CUDA primarly, set this ON
-
-add_executable(conv conv.c)
-
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
- find_package(PkgConfig)
- find_package(OpenCL)
-endif()
-
 string(TIMESTAMP TS)
 add_definitions(-DBUILD_TS="${TS}")
 
-if (${OPENCV_PKG_FOUND})
- set(CMAKE_REQUIRED_INCLUDES ${OPENCV_PKG_INCLUDE_DIRS})
- include_directories(${OPENCV_PKG_INCLUDE_DIRS})
- link_directories(${OPENCV_PKG_LIBRARY_DIRS})
-else()
- set(OPENCV_PREFIX "/usr/local" CACHE FILEPATH "OpenCV 3.x path")
- set(CMAKE_REQUIRED_INCLUDES ${OPENCV_PREFIX}/include)
- include_directories(${OPENCV_PREFIX}/include)
- link_directories(${OPENCV_PREFIX}/lib)
+CMAKE_DEPENDENT_OPTION(FORCE_AMD "Whether to force detection of AMDSDK" OFF "NOT FORCE_CUDA" OFF) # When you have CUDASDK and AMDSDK installed but want to detect AMD primarly, set this ON
+CMAKE_DEPENDENT_OPTION(FORCE_CUDA "Whether to force detection of CUDASDK" OFF "NOT FORCE_AMD" OFF) # When you have CUDASDK and AMDSDK installed but want to detect CUDA primarly, set this ON
+
+set(LOCAL_SYS_TYPE "unknown")
+if (MINGW)
+	set(LOCAL_SYS_TYPE "MinGW")
+endif()
+if (UNIX)
+	set(LOCAL_SYS_TYPE "Linux")
+endif()
+if (APPLE)
+	set(LOCAL_SYS_TYPE "Apple")
+endif()
+if (MSVC)
+	set(LOCAL_SYS_TYPE "MSVC")
+endif()
+message("-- We are on: ${CMAKE_SYSTEM_NAME} (${LOCAL_SYS_TYPE})")
+
+if(UNIX OR MINGW)
+	set(FILE_SYSTEM_LIB "stdc++fs")
 endif()
 
-# old stuff
-# if(OVERRIDE_OPENCV)
- # set(HAVE_OPENCV 1 CACHE INTERNAL "Have include opencv overridden")
- # message("OpenCV detection overridden")
-# else()
- # check_include_file_cxx("${OPENCV_PREFIX}/include/opencv2/opencv.hpp" HAVE_OPENCV)
-# endif()
-
-if(NOT HAVE_OPENCV)
- if(EXISTS "${OPENCV_PREFIX}/include/opencv2/opencv.hpp")
-	set(HAVE_OPENCV TRUE)
- endif()
+add_executable(conv conv.c)
+if(UNIX)
+	set(OPENCV_PREFIX "/usr" CACHE FILEPATH "OpenCV path")
+	find_package(PkgConfig)
+	find_package(OpenCV)
+	if(${OPENCV_FOUND})
+		set(HAVE_OPENCV TRUE)
+		set(CMAKE_REQUIRED_INCLUDES ${OpenCV_INCLUDE_DIR})
+		include_directories(${OpenCV_INCLUDE_DIR})
+		CHECK_INCLUDE_FILE_CXX("${OPENCV_PREFIX}/include/opencv2/opencv.hpp" HAVE_OPENCV)
+		if (HAVE_OPENCV)
+			link_directories(${OPENCV_PREFIX}/lib)
+		endif()
+	endif()
+elseif(WIN32) # Windows has no pkgconfig nor FindOpenCV apparently
+	set(OPENCV_PREFIX "opencv" CACHE FILEPATH "OpenCV 3.x path") # No real default path for windows, assume subfolder in source folder
+	include_directories(${OPENCV_PREFIX}/include)
+	link_directories(${OPENCV_PREFIX}/lib)
+	#set(CMAKE_REQUIRED_INCLUDES ${OPENCV_PREFIX}/include)
+	#CHECK_INCLUDE_FILE_CXX("${OPENCV_PREFIX}/include/opencv2/opencv.hpp" HAVE_OPENCV)
+	if(EXISTS "${OPENCV_PREFIX}/include/opencv2/opencv.hpp")
+		set(HAVE_OPENCV TRUE)
+		message(STATUS "Found OpenCV")
+	else()
+		message(FATAL_ERROR "Could not find OpenCV")
+	endif()
 endif()
 
-find_library(IMGCODECS_LIBRARY NAMES opencv_imgcodecs opencv_highgui HINTS ${OPENCV_PKG_INCLUDE_DIRS} ${OPENCV_PREFIX}/lib)
+find_library(IMGCODECS_LIBRARY NAMES opencv_imgcodecs opencv_highgui HINTS ${OPENCV_PREFIX}/lib)
 
 if(HAVE_OPENCV)
- message("-- Found OpenCV")
- add_definitions(-DHAVE_OPENCV)
- set(OPENCV_LIBRARIES opencv_core opencv_imgproc ${IMGCODECS_LIBRARY} opencv_features2d)
-else()
- message("OpenCV not found, make sure OPENCV_PREFIX is set or on Linux, make sure the pkg-config file exists")
+	add_definitions(-DHAVE_OPENCV)
+	set(OPENCV_LIBRARIES opencv_core opencv_imgproc ${IMGCODECS_LIBRARY} opencv_features2d)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	# include_directories("/usr")
-else()
+if(WIN32)
 	if(FORCE_AMD)
 		set(FindAMDCL_DIR ".")
 		find_package(FindAMDCL REQUIRED)
@@ -76,9 +86,9 @@ else()
 endif()
 
 if(CUDA_FOUND)
- add_definitions(-DHAVE_CUDA)
+	add_definitions(-DHAVE_CUDA)
 else()
- message("-- CUDA not found. disabled.")
+	message("-- CUDA not found. disabled.")
 endif()
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -86,37 +96,38 @@ include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
- if(CMAKE_COMPILER_IS_GNUCXX)
-	set(OCV_COMPILER_DIRNAME "mingw")
- elseif(MSVC11)
-	set(OCV_COMPILER_DIRNAME "vc11")
- elseif(MSVC14)
-	#message(WARNING "VC14 found, which is NOT FULLY tested.")
-	set(OCV_COMPILER_DIRNAME "vc14")
- else()
-	set(OCV_COMPILER_DIRNAME "vc12")
- endif()
+	if(MINGW)
+		set(OCV_COMPILER_DIRNAME "mingw")
+	elseif(MSVC11)
+		set(OCV_COMPILER_DIRNAME "vc11")
+	elseif(MSVC14)
+		set(OCV_COMPILER_DIRNAME "vc14")
+	else()
+		set(OCV_COMPILER_DIRNAME "vc12")
+	endif()
 
- if(MSVC)
-	set(CMAKE_CXX_FLAGS_RELEASE "/O2 /MT")
-	set(CMAKE_CXX_FLAGS_DEBUG "/Zi /MT")
- endif()
+	if(MSVC)
+		set(CMAKE_CXX_FLAGS_RELEASE "/O2 /MT")
+		set(CMAKE_CXX_FLAGS_DEBUG "/Zi /MT")
+	endif()
 
- if(CMAKE_COMPILER_IS_GNUCXX)
-	SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-	SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static")
- endif()
+	if(MINGW)
+		SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+		SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static")
+	endif()
 
- if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-	set(OCV_SYSTEM_DIRNAME "x64")
- else()
-	set(OCV_SYSTEM_DIRNAME "x86")
- endif()
- if(MSVC14)
-	link_directories(${OPENCV_PREFIX}/${OCV_SYSTEM_DIRNAME}/${OCV_COMPILER_DIRNAME}/lib)
- else()
-	link_directories(${OPENCV_PREFIX}/${OCV_SYSTEM_DIRNAME}/${OCV_COMPILER_DIRNAME}/staticlib)
- endif()
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(OCV_SYSTEM_DIRNAME "x64")
+	else()
+		set(OCV_SYSTEM_DIRNAME "x86")
+	endif()
+
+	if(MSVC14)
+		link_directories(${OPENCV_PREFIX}/${OCV_SYSTEM_DIRNAME}/${OCV_COMPILER_DIRNAME}/lib)
+	else()
+		link_directories(${OPENCV_PREFIX}/${OCV_SYSTEM_DIRNAME}/${OCV_COMPILER_DIRNAME}/staticlib)
+	endif()
+
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR
@@ -124,189 +135,171 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR
 	CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
 	CMAKE_SYSTEM_PROCESSOR STREQUAL "x86" OR
 	CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
- set(X86_TRUE true)
+	set(X86_TRUE true)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch|^arm")
- set(ARM_TRUE true)
+	set(ARM_TRUE true)
 else()
- set(X86_TRUE false)
+	set(X86_TRUE false)
 endif()
 
 option(X86OPT "Enable X86 SIMD optimizations" ${X86_TRUE})
 if(X86OPT)
- add_definitions(-DX86OPT)
- set(OPT_SOURCES src/modelHandler_avx.cpp src/modelHandler_fma.cpp src/modelHandler_sse.cpp)
+	add_definitions(-DX86OPT)
+	set(OPT_SOURCES src/modelHandler_avx.cpp src/modelHandler_fma.cpp src/modelHandler_sse.cpp)
 endif()
 
 option(ARMOPT "Enable ARM SIMD optimizations" ${ARM_TRUE})
 if(ARMOPT)
- add_definitions(-DARMOPT)
- set(OPT_SOURCES src/modelHandler_neon.cpp)
+	add_definitions(-DARMOPT)
+	set(OPT_SOURCES src/modelHandler_neon.cpp)
 
- include(CheckCXXCompilerFlag)
- # -mfloat-abi=hard and -mfloat-abi=softfp cannot be mixed
- # -mfpu=neon and -march=armv7-a are not supported on armv8
- foreach(flag -mfloat-abi=hard -mfloat-abi=softfp -mfpu=neon -march=armv7-a -lstdc++fs)
-	string(REGEX REPLACE "[-=]" "_" flagp ${flag})
-	check_cxx_compiler_flag(${flag} ${flagp})
-	if(${flagp} AND NOT ${flag} MATCHES "-march")
-	 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-	endif()
- endforeach()
+	include(CheckCXXCompilerFlag)
+	# -mfloat-abi=hard and -mfloat-abi=softfp cannot be mixed
+	# -mfpu=neon and -march=armv7-a are not supported on armv8
+	foreach(flag -mfloat-abi=hard -mfloat-abi=softfp -mfpu=neon -march=armv7-a -lstdc++fs)
+		string(REGEX REPLACE "[-=]" "_" flagp ${flag})
+		check_cxx_compiler_flag(${flag} ${flagp})
+		if(${flagp} AND NOT ${flag} MATCHES "-march")
+			set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+		endif()
+	endforeach()
 endif()
 
 
 add_library(w2xc SHARED
- src/modelHandler.cpp ${OPT_SOURCES}
- src/modelHandler_OpenCL.cpp src/convertRoutine.cpp src/threadPool.cpp
- src/modelHandler_CUDA.cpp src/w2xconv.cpp src/common.cpp
- src/cvwrap.cpp
- src/Env.cpp src/Buffer.cpp
+	src/modelHandler.cpp ${OPT_SOURCES}
+	src/modelHandler_OpenCL.cpp src/convertRoutine.cpp src/threadPool.cpp
+	src/modelHandler_CUDA.cpp src/w2xconv.cpp src/common.cpp
+	src/cvwrap.cpp
+	src/Env.cpp src/Buffer.cpp
 )
 
 add_dependencies(w2xc gensrcs)
 
 
 if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
- set(CMAKE_CXX_STANDARD 17)
- # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++1z")
- set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+	set(CMAKE_CXX_STANDARD 17)
+	# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++1z")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
- if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	set(REMOVE_SYMBOL "")
- else()
-	set(REMOVE_SYMBOL "-s")
- endif()
+	if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+		set(REMOVE_SYMBOL "")
+	else()
+		set(REMOVE_SYMBOL "-s")
+	endif()
 
- set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${REMOVE_SYMBOL}")
+	set(CMAKE_CXX_FLAGS_RELEASE "-O2 ${REMOVE_SYMBOL}")
 
- set_source_files_properties(src/modelHandler_avx.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -mavx ${REMOVE_SYMBOL}")
- set_source_files_properties(src/modelHandler_fma.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -mfma ${REMOVE_SYMBOL}")
- set_source_files_properties(src/modelHandler_sse.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -save-temps -msse3 ${REMOVE_SYMBOL}")
- if(_march_armv7_a)
-	set_source_files_properties(src/modelHandler_neon.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -march=armv7-a ${REMOVE_SYMBOL}")
- endif()
+	set_source_files_properties(src/modelHandler_avx.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -mavx ${REMOVE_SYMBOL}")
+	set_source_files_properties(src/modelHandler_fma.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -mfma ${REMOVE_SYMBOL}")
+	set_source_files_properties(src/modelHandler_sse.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -save-temps -msse3 ${REMOVE_SYMBOL}")
+	if(_march_armv7_a)
+		set_source_files_properties(src/modelHandler_neon.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} -O2 -march=armv7-a ${REMOVE_SYMBOL}")
+	endif()
 elseif(MSVC)
- set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4819 /wd4996 /wd4800")
- set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4819 /wd4996 /wd4800")
- set_source_files_properties(src/modelHandler_avx.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} /O2 /arch:AVX")
- set_source_files_properties(src/modelHandler_fma.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} /O2 /arch:AVX2")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4819 /wd4996 /wd4800")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4819 /wd4996 /wd4800")
+	set_source_files_properties(src/modelHandler_avx.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} /O2 /arch:AVX")
+	set_source_files_properties(src/modelHandler_fma.cpp PROPERTIES COMPILE_FLAGS "${CMAKE_CXX_FLAGS} /O2 /arch:AVX2")
 endif()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)
- list(APPEND CUDA_NVCC_FLAGS "-m32")
+	list(APPEND CUDA_NVCC_FLAGS "-m32")
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
- if(CUDA_FOUND)
-	list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "/wd 4819")
- endif()
- set_target_properties(w2xc PROPERTIES PREFIX "")
- set_target_properties(w2xc PROPERTIES IMPORT_PREFIX "")
- set_target_properties(w2xc PROPERTIES IMPORT_SUFFIX ".lib")
+if(WIN32)
+	if(CUDA_FOUND)
+		list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "/wd 4819")
+	endif()
+	set_target_properties(w2xc PROPERTIES PREFIX "")
+	set_target_properties(w2xc PROPERTIES IMPORT_PREFIX "")
+	set_target_properties(w2xc PROPERTIES IMPORT_SUFFIX ".lib")
 else()
- # Lower GCC version to avoid #error in host_config.h
- find_program(GCC NAMES g++-4.7 g++47 g++-4.8 g++48)
- if(GCC)
-	list(APPEND CUDA_NVCC_FLAGS "-ccbin" "${GCC}")
- endif()
+	# Lower GCC version to avoid #error in host_config.h
+	find_program(GCC NAMES g++-4.7 g++47 g++-4.8 g++48)
+	if(GCC)
+		list(APPEND CUDA_NVCC_FLAGS "-ccbin" "${GCC}")
+	endif()
 endif()
 
-set(LOCAL_SYS_TYPE "UNKNOWN")
-if (MINGW)
-	set(LOCAL_SYS_TYPE "MINGW")
-endif()
-if (LINUX)
-	set(LOCAL_SYS_TYPE "LINUX")
-endif()
-if (APPLE)
-	set(LOCAL_SYS_TYPE "APPLE")
-endif()
-if (MSVC)
-	set(LOCAL_SYS_TYPE "MSVC")
-endif()
-
-message("-- We are on: ${CMAKE_SYSTEM_NAME} -> ${LOCAL_SYS_TYPE}")
-
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows") # We build FOR windows.
+if(WIN32) # We build FOR windows.
 	if(MINGW) # We build for windows on Linux MinGW (Cross compiling) # not yet working
-		target_link_libraries(w2xc
-		opencv_core300 opencv_imgproc300 opencv_imgcodecs300 opencv_features2d300 libjpeg libpng libtiff libjasper opencv_hal300
-		IlmImf zlib libwebp user32 opencv_core300 opencv_hal300) # xx 300
+		target_link_libraries(w2xc opencv_core300 opencv_imgproc300 opencv_imgcodecs300 opencv_features2d300 libjpeg libpng libtiff libjasper opencv_hal300 IlmImf zlib libwebp user32 opencv_core300 opencv_hal300) # xx 300
 	elseif(MSVC) # we build natively on Visual studio
 		target_link_libraries(w2xc opencv_world330 user32)
-	elseif(LINUX) # we build on linux.... on windows.. somehow WSL?/Cygwin? We'll see
-		target_link_libraries(w2xc opencv_core300 opencv_imgproc300 opencv_imgcodecs300
-		opencv_features2d300 ippicvmt libjpeg libpng libtiff libjasper
-		opencv_hal300 IlmImf zlib libwebp user32 opencv_core300 opencv_imgproc300)
+	elseif(UNIX) # we build on linux.... on windows.. somehow WSL?/Cygwin? We'll see
+		target_link_libraries(w2xc opencv_core300 opencv_imgproc300 opencv_imgcodecs300 opencv_features2d300 ippicvmt libjpeg libpng libtiff libjasper opencv_hal300 IlmImf zlib libwebp user32 opencv_core300 opencv_imgproc300)
 	endif()
-		add_executable(w2xcr WIN32 w32-apps/w2xcr.c w32-apps/w2xcr.rc)
-		target_link_libraries(w2xcr w2xc user32 shlwapi gdi32)
-else() # we are on linux and build for linux
-	target_link_libraries(w2xc ${OPENCV_LIBRARIES} ${CMAKE_DL_LIBS} pthread stdc++fs stdc++)
+	add_executable(w2xcr WIN32 w32-apps/w2xcr.c w32-apps/w2xcr.rc)
+	target_link_libraries(w2xcr w2xc user32 shlwapi gdi32)
+else() # We are on linux and build for linux
+	target_link_libraries(w2xc ${OpenCV_LIBS} ${CMAKE_DL_LIBS} pthread stdc++fs stdc++)
 endif()
 
 set(CONV_EXE "$<TARGET_FILE_DIR:conv>/conv")
 
 add_custom_command(
- OUTPUT modelHandler_OpenCL.cl.h
- COMMAND ${CONV_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_OpenCL.cl ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_OpenCL.cl.h str
- DEPENDS src/modelHandler_OpenCL.cl conv
- )
+	OUTPUT modelHandler_OpenCL.cl.h
+	COMMAND ${CONV_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_OpenCL.cl ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_OpenCL.cl.h str
+	DEPENDS src/modelHandler_OpenCL.cl conv
+)
 
 set(GPU_CODE modelHandler_OpenCL.cl.h)
 
 if(CUDA_FOUND)
- add_custom_command(
-	OUTPUT modelHandler_CUDA.ptx20.h
-	COMMAND ${CONV_EXE} modelHandler_CUDA.ptx20 modelHandler_CUDA.ptx20.h str
-	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 conv
+	add_custom_command(
+		OUTPUT modelHandler_CUDA.ptx20.h
+		COMMAND ${CONV_EXE} modelHandler_CUDA.ptx20 modelHandler_CUDA.ptx20.h str
+		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 conv
 	)
-
- add_custom_command(
-	OUTPUT modelHandler_CUDA.ptx30.h
-	COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
-	DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 conv
+	add_custom_command(
+		OUTPUT modelHandler_CUDA.ptx30.h
+		COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
+		DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 conv
 	)
-
- add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20
-	COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_20 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
-	DEPENDS src/modelHandler_CUDA.cu
+	add_custom_command(
+		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20
+		COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_20 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+		DEPENDS src/modelHandler_CUDA.cu
 	)
- add_custom_command(
-	OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30
-	COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_30 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
-	DEPENDS src/modelHandler_CUDA.cu
+	add_custom_command(
+		OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30
+		COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_30 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+		DEPENDS src/modelHandler_CUDA.cu
 	)
-
- set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
+	set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
 endif()
 
-add_custom_target(gensrcs ALL
- DEPENDS ${GPU_CODE})
-
+add_custom_target(gensrcs ALL DEPENDS ${GPU_CODE})
 enable_testing()
 
 if (${HAVE_OPENCV})
- add_executable(waifu2x-converter-cpp
-	src/main.cpp)
+	add_executable(waifu2x-converter-cpp src/main.cpp)
 
- if(MSVC)
- 	target_link_libraries(waifu2x-converter-cpp LINK_PUBLIC w2xc)
- else()
- 	target_link_libraries(waifu2x-converter-cpp LINK_PUBLIC w2xc stdc++fs)
- endif()
+	if(MSVC)
+		target_link_libraries(waifu2x-converter-cpp LINK_PUBLIC w2xc)
+	elseif(MINGW)
+		target_link_libraries(waifu2x-converter-cpp LINK_PUBLIC w2xc ${FILE_SYSTEM_LIB})
+	elseif(UNIX)
+		target_link_libraries(waifu2x-converter-cpp LINK_PUBLIC w2xc ${FILE_SYSTEM_LIB})
+	endif()
 
- add_executable(runtest w32-apps/runtest.c)
- target_link_libraries(runtest w2xc stdc++fs stdc++)
- add_test(runtest runtest)
-
- install(TARGETS w2xc waifu2x-converter-cpp RUNTIME DESTINATION bin LIBRARY DESTINATION "lib${LIB_SUFFIX}" ARCHIVE DESTINATION "lib${LIB_SUFFIX}" )
+	add_executable(runtest w32-apps/runtest.c)
+	if(WIN32)
+		target_link_libraries(runtest w2xc ${FILE_SYSTEM_LIB})
+	else()
+		target_link_libraries(runtest w2xc ${FILE_SYSTEM_LIB} stdc++)
+	endif()
+	add_test(runtest runtest)
+	install(TARGETS w2xc waifu2x-converter-cpp RUNTIME DESTINATION bin LIBRARY DESTINATION "lib${LIB_SUFFIX}" ARCHIVE DESTINATION "lib${LIB_SUFFIX}" )
 endif()
 
 add_executable(runbench w32-apps/runbench.c)
-target_link_libraries(runbench LINK_PUBLIC w2xc stdc++fs stdc++)
-
+if(WIN32)
+	target_link_libraries(runbench LINK_PUBLIC w2xc ${FILE_SYSTEM_LIB})
+else()
+	target_link_libraries(runbench LINK_PUBLIC w2xc ${FILE_SYSTEM_LIB} stdc++)
+endif()
 install(FILES src/w2xconv.h DESTINATION include)
 
 # Better add support for multiple directories where to find models

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(conv conv.c)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
  find_package(PkgConfig)
- pkg_check_modules(OPENCV_PKG opencv)
+ find_package(OpenCL)
 endif()
 
 string(TIMESTAMP TS)
@@ -211,23 +211,38 @@ else()
  endif()
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
- if(CMAKE_COMPILER_IS_GNUCXX)
-	target_link_libraries(w2xc
-	 opencv_core300 opencv_imgproc300 opencv_imgcodecs300 opencv_features2d300 libjpeg libpng libtiff libjasper opencv_hal300
-	 IlmImf zlib libwebp user32 opencv_core300 opencv_hal300) # xx 300
- elseif(MSVC14)
-	 target_link_libraries(w2xc opencv_world330 user32)
- else()
-	target_link_libraries(w2xc opencv_core300 opencv_imgproc300 opencv_imgcodecs300
-	 opencv_features2d300 ippicvmt libjpeg libpng libtiff libjasper
-	 opencv_hal300 IlmImf zlib libwebp user32 opencv_core300 opencv_imgproc300)
- endif()
+set(LOCAL_SYS_TYPE "UNKNOWN")
+if (MINGW)
+	set(LOCAL_SYS_TYPE "MINGW")
+endif()
+if (LINUX)
+	set(LOCAL_SYS_TYPE "LINUX")
+endif()
+if (APPLE)
+	set(LOCAL_SYS_TYPE "APPLE")
+endif()
+if (MSVC)
+	set(LOCAL_SYS_TYPE "MSVC")
+endif()
 
- add_executable(w2xcr WIN32 w32-apps/w2xcr.c w32-apps/w2xcr.rc)
- target_link_libraries(w2xcr w2xc user32 shlwapi gdi32)
-else()
- target_link_libraries(w2xc ${OPENCV_LIBRARIES} ${CMAKE_DL_LIBS} pthread)
+message("-- We are on: ${CMAKE_SYSTEM_NAME} -> ${LOCAL_SYS_TYPE}")
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows") # We build FOR windows.
+	if(MINGW) # We build for windows on Linux MinGW (Cross compiling) # not yet working
+		target_link_libraries(w2xc
+		opencv_core300 opencv_imgproc300 opencv_imgcodecs300 opencv_features2d300 libjpeg libpng libtiff libjasper opencv_hal300
+		IlmImf zlib libwebp user32 opencv_core300 opencv_hal300) # xx 300
+	elseif(MSVC) # we build natively on Visual studio
+		target_link_libraries(w2xc opencv_world330 user32)
+	elseif(LINUX) # we build on linux.... on windows.. somehow WSL?/Cygwin? We'll see
+		target_link_libraries(w2xc opencv_core300 opencv_imgproc300 opencv_imgcodecs300
+		opencv_features2d300 ippicvmt libjpeg libpng libtiff libjasper
+		opencv_hal300 IlmImf zlib libwebp user32 opencv_core300 opencv_imgproc300)
+	endif()
+		add_executable(w2xcr WIN32 w32-apps/w2xcr.c w32-apps/w2xcr.rc)
+		target_link_libraries(w2xcr w2xc user32 shlwapi gdi32)
+else() # we are on linux and build for linux
+	target_link_libraries(w2xc ${OPENCV_LIBRARIES} ${CMAKE_DL_LIBS} pthread stdc++fs stdc++)
 endif()
 
 set(CONV_EXE "$<TARGET_FILE_DIR:conv>/conv")
@@ -283,14 +298,14 @@ if (${HAVE_OPENCV})
  endif()
 
  add_executable(runtest w32-apps/runtest.c)
- target_link_libraries(runtest w2xc)
+ target_link_libraries(runtest w2xc stdc++fs stdc++)
  add_test(runtest runtest)
 
  install(TARGETS w2xc waifu2x-converter-cpp RUNTIME DESTINATION bin LIBRARY DESTINATION "lib${LIB_SUFFIX}" ARCHIVE DESTINATION "lib${LIB_SUFFIX}" )
 endif()
 
 add_executable(runbench w32-apps/runbench.c)
-target_link_libraries(runbench LINK_PUBLIC w2xc)
+target_link_libraries(runbench LINK_PUBLIC w2xc stdc++fs stdc++)
 
 install(FILES src/w2xconv.h DESTINATION include)
 

--- a/src/modelHandler_OpenCL.cpp
+++ b/src/modelHandler_OpenCL.cpp
@@ -16,6 +16,16 @@
 #include "CLlib.h"
 #include "params.h"
 #include "CL/cl.h"
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
+
+
+#ifdef __linux
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#endif
 
 static const char prog[] =
 #include "modelHandler_OpenCL.cl.h"
@@ -304,6 +314,7 @@ namespace w2xc {
 
 		std::string dev_nameStr = &dev_name[0];
 		removeForbiddenChar(&dev_nameStr);
+		
 		std::string bin_path = std::string(self_path) + "/" + dev_nameStr + ".bin";
 
 		FILE *binfp = fopen(bin_path.c_str(), "rb");
@@ -420,8 +431,47 @@ namespace w2xc {
 			ptrs[0] = buffer;
 
 			clGetProgramInfo(program, CL_PROGRAM_BINARIES, sizeof(ptrs), ptrs, &ret_len);
-
-			FILE *fp = fopen(bin_path.c_str(), "wb");
+			
+			FILE *fp = NULL;
+			while (fp == NULL)
+			{
+				fp = fopen(bin_path.c_str(), "wb");
+				if (fp == NULL) {
+					#if (defined __linux)
+						if (errno == 13) {
+							std::string user_folder("/tmp/.waifu2x");
+							// printf("______w_%s_______\n" , user_folder.c_str());
+							char *home_dir = getenv ("HOME");
+							// printf("______w_%s_______\n" , home_dir);
+							if (home_dir != NULL) {
+								user_folder = std::string(home_dir) + "/.waifu2x";
+							}
+							
+							if (!fs::exists(user_folder)) {
+								// printf("__got here___3\n");
+								try { fs::create_directory(user_folder); }
+								catch (fs::filesystem_error& e) {
+									printf("ERROR: %s\n",e.what());
+									exit(EXIT_FAILURE);
+								}
+							}
+							// printf("__got here___2\n");
+							bin_path = user_folder + "/" + dev_nameStr + ".bin";
+							fp = fopen(bin_path.c_str(), "wb");
+							printf("Writing OpenCL-Binary to: %s\n",bin_path.c_str());
+						}
+						else {
+							printf("Error opening file %s: [%d] %s\n",bin_path.c_str(),errno,strerror(errno));
+							exit (EXIT_FAILURE);
+						}
+					#else
+						printf("Error opening file %s: [%d] %s\n",bin_path.c_str(),errno,strerror(errno));
+						exit (EXIT_FAILURE);
+					#endif
+				}
+				else { printf("Writing OpenCL-Binary to: %s\n",bin_path.c_str()); }
+			}
+			
 
 			size_t rem = binsz;
 			char *p = buffer;


### PR DESCRIPTION
Instead of trying to write and load the binary of the executable directory, e.g /usr/bin w2x will now try to write and read it from the the home directory, to which the user actually has access.

Also fixed the package detection on Windows and Linux.
