### PR TITLE
Added counter of processed files and output of approximate remaining time.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -364,7 +364,7 @@ int main(int argc, char** argv) {
 	if (fs::is_directory(input) == true) {
 		//Build files list
 		std::deque<fs::path> files_list;
-		std::cout << "We're going to be operating in a directory. dir:" << fs::absolute(input) << std::endl;
+		std::cout << "We're going to be operating in a directory. dir:" << fs::absolute(input) << std::endl << std::endl;
 		if (recursive_directory_iterator) {
 			for (auto & inputFile : fs::recursive_directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <string>
 #include <cmath>
+#include <deque>
 #include "tclap/CmdLine.h"
 #include "sec.hpp"
 #include <experimental/filesystem>
@@ -194,7 +195,7 @@ std::string generate_output_location(std::string inputFileName, std::string outp
 
 
 void convert_file(convInfo info, fs::path inputName, fs::path output) {
-	std::cout << "Operating on: " << fs::absolute(inputName).string() << std::endl;
+	//std::cout << "Operating on: " << fs::absolute(inputName).string() << std::endl;
 	std::string outputName = generate_output_location(fs::absolute(inputName).string(), output.string(), info.mode, info.NRLevel, info.scaleRatio);
 
 	int _nrLevel = 0;
@@ -361,37 +362,60 @@ int main(int argc, char** argv) {
 	int numFilesProcessed = 0;
 	int numErrors = 0;
 	if (fs::is_directory(input) == true) {
+		//Build files list
+		std::deque<fs::path> files_list;
 		std::cout << "We're going to be operating in a directory. dir:" << fs::absolute(input) << std::endl;
 		if (recursive_directory_iterator) {
 			for (auto & inputFile : fs::recursive_directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {
-					numFilesProcessed++;
-					try {
-						convert_file(convInfo, inputFile, output);
-					}
-					catch (const std::exception& e) {
-						numErrors++;
-						std::cout << e.what() << std::endl;
-					}
+					files_list.push_back(inputFile);
 				}
 			}
 		}
 		else {
 			for (auto & inputFile : fs::directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {
-					numFilesProcessed++;
-					try {
-						convert_file(convInfo, inputFile, output);
-					}
-					catch (const std::exception& e) {
-						numErrors++;
-						std::cout << e.what() << std::endl;
-					}
+					files_list.push_back(inputFile);
 				}
 			}
 		}
 
+		//Proceed by list
+		double timeAvg = 0.0;
+		int files_count = static_cast<int>(files_list.size());
+		for (auto &fn : files_list) {
+			++numFilesProcessed;
+			double time_file_start = getsec();
 
+			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename();
+
+			try {
+				convert_file(convInfo, fn, output);
+			}
+			catch (const std::exception& e) {
+				numErrors++;
+				std::cout << e.what() << std::endl;
+			}
+
+			//Calculate and out elapsed time
+			double time_end = getsec();
+			double time_file = time_end - time_file_start;
+			double time_all = time_end - time_start;
+			if (timeAvg > 0.0)
+				timeAvg = time_all / numFilesProcessed;
+			else
+				timeAvg = time_all;
+			double elapsed = files_count * timeAvg - time_all;
+			int el_h = elapsed / (60 * 60);
+			int el_m = (elapsed - el_h * 60 * 60) / 60;
+			int el_s = (elapsed - el_h * 60 * 60 - el_m * 60);
+			std::cout << " (elapsed: ";
+			if (el_h)
+				std::cout << el_h << "h";
+			if (el_m)
+				std::cout << el_m << "m";
+			std::cout << el_s << "s file: " << time_file << "s avg: " << timeAvg << "s)" << std::endl;
+		}
 
 
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,11 +387,7 @@ int main(int argc, char** argv) {
 			++numFilesProcessed;
 			double time_file_start = getsec();
 
-			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename();
-			if (verbose)
-				std::cout << std::endl;
-			else
-				std::cout << " Ok. ";
+			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << (verbose ? "\n" : " Ok. ");
 
 			try {
 				convert_file(convInfo, fn, output);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -364,7 +364,7 @@ int main(int argc, char** argv) {
 	if (fs::is_directory(input) == true) {
 		//Build files list
 		std::deque<fs::path> files_list;
-		std::cout << "We're going to be operating in a directory. dir:" << fs::absolute(input) << std::endl << std::endl;
+		std::cout << "We're going to be operating in a directory. dir:" << fs::absolute(input) << std::endl;
 		if (recursive_directory_iterator) {
 			for (auto & inputFile : fs::recursive_directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,7 +387,11 @@ int main(int argc, char** argv) {
 			++numFilesProcessed;
 			double time_file_start = getsec();
 
-			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << (verbose ? std::endl : " Ok. ");
+			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename();
+			if (verbose)
+				std::cout << std::endl;
+			else
+				std::cout << " Ok. ";
 
 			try {
 				convert_file(convInfo, fn, output);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,7 +387,7 @@ int main(int argc, char** argv) {
 			++numFilesProcessed;
 			double time_file_start = getsec();
 
-			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename();
+			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << std::endl;
 
 			try {
 				convert_file(convInfo, fn, output);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -387,7 +387,7 @@ int main(int argc, char** argv) {
 			++numFilesProcessed;
 			double time_file_start = getsec();
 
-			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << std::endl;
+			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << (verbose ? std::endl : " Ok. ");
 
 			try {
 				convert_file(convInfo, fn, output);
@@ -409,12 +409,12 @@ int main(int argc, char** argv) {
 			int el_h = elapsed / (60 * 60);
 			int el_m = (elapsed - el_h * 60 * 60) / 60;
 			int el_s = (elapsed - el_h * 60 * 60 - el_m * 60);
-			std::cout << " (elapsed: ";
+			std::cout << "Elapsed: ";
 			if (el_h)
 				std::cout << el_h << "h";
 			if (el_m)
 				std::cout << el_m << "m";
-			std::cout << el_s << "s file: " << time_file << "s avg: " << timeAvg << "s)" << std::endl;
+			std::cout << el_s << "s file: " << time_file << "s avg: " << timeAvg << "s" << std::endl;
 		}
 
 


### PR DESCRIPTION
The code was rewritten from the old version of the converter.
Example output:
```
D:\Projects\waifu2x-converter-cpp\output\Release>waifu2x-converter-cpp.exe --mode noise_scale -q -i .\to_conv\ -o .\out\
CUDA: GeForce GTX 960
We're going to be operating in a directory. dir:D:\Projects\waifu2x-converter-cpp\output\Release\.\to_conv\
[1/4] 024f1c79df86.jpg (elapsed: 4s file: 1.38006s avg: 1.44535s)
[2/4] 03f662LvrLo.jpg (elapsed: 1s file: 0.269408s avg: 0.858336s)
[3/4] 0yLq0KXk8cY.jpg (elapsed: 0s file: 0.269567s avg: 0.663074s)
[4/4] 12063214_463445740528642_1095354792_n.jpg (elapsed: 0s file: 0.68575s avg: 0.669358s)
process successfully done! (all:2.67904[sec], 4 [files processed], 0 [files errored], 741.043[GFLOPS], filter:2.22665[sec], 891.603[GFLOPS])
```