### PR TITLE
buildguide: add requirements of gcc version

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -63,7 +63,7 @@ Install both SDK's as shown above, but later add "-DFORCE_DUAL=ON" to the cmake 
 # Linux
 
 ### Requirements:
-- GCC
+- GCC 5+
 - CMake
 - OpenCV 3+
 


### PR DESCRIPTION
c++17 is only provided in gcc 5 or grater

See: [https://gcc.gnu.org/projects/cxx-status.html#cxx17](https://gcc.gnu.org/projects/cxx-status.html#cxx17)