### PR TITLE
buildguide: changed require version of gcc

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -63,7 +63,7 @@ Install both SDK's as shown above, but later add "-DFORCE_DUAL=ON" to the cmake 
 # Linux
 
 ### Requirements:
-- GCC 5+
+- GCC 6+
 - CMake
 - OpenCV 3+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ project(waifu2xcpp)
 include("CMakeDependentOption")
 include("CheckIncludeFileCXX")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0")
+    message(FATAL_ERROR "This software requires GCC 6 or higher")
+  endif()
+endif()
+
 string(TIMESTAMP TS)
 add_definitions(-DBUILD_TS="${TS}")
 


### PR DESCRIPTION
I tested gcc version 4.5~gcc 6, waifu2x-convterter-cpp needs at least version 6 of gcc (c++17 is not fully supported in gcc 4 ~ gcc 5)

check #69 & #70