### PR TITLE
Test level source for unicode support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,15 @@ if(HAVE_OPENCV)
 endif()
 
 if(FORCE_AMD)
-	message("-- -FORCE_AMD=ON is set, not using cuda")
+	message("-- FORCE_AMD=ON is set, not using cuda")
 else()
 	find_package(CUDA)
+endif()
+
+if(BUILD_UNICODE)
+	add_definitions(-DUNICODE)
+	add_definitions(-D_UNICODE)
+	message("-- BUILD_UNICODE=ON is set, Compiles with UNICODE Mode")
 endif()
 
 if(WIN32)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -171,16 +171,16 @@ update_test(const char *dst_path,
 	    const char *src_path)
 {
 #if (defined _WIN32)
-	WIN32_FIND_DATA dst_st;
-	HANDLE finder = FindFirstFile(dst_path, &dst_st);
+	WIN32_FIND_DATAA dst_st;
+	HANDLE finder = FindFirstFileA(dst_path, &dst_st);
 	if (finder == INVALID_HANDLE_VALUE) {
 		return true;
 	}
 
 	FindClose(finder);
 
-	WIN32_FIND_DATA src_st;
-	finder = FindFirstFile(src_path, &src_st);
+	WIN32_FIND_DATAA src_st;
+	finder = FindFirstFileA(src_path, &src_st);
 	FindClose(finder);
 
 	bool old = false;

--- a/src/modelHandler_CUDA.cpp
+++ b/src/modelHandler_CUDA.cpp
@@ -42,7 +42,7 @@ void
 initCUDAGlobal(std::vector<W2XConvProcessor> *proc_list)
 {
 #ifdef _WIN32
-	handle = LoadLibrary("nvcuda.dll");
+	handle = LoadLibraryA("nvcuda.dll");
 #elif defined __APPLE__
 	handle = dlopen("libcuda.dylib", RTLD_LAZY);
 #define GetProcAddress dlsym

--- a/src/modelHandler_OpenCL.cpp
+++ b/src/modelHandler_OpenCL.cpp
@@ -54,7 +54,7 @@ namespace w2xc {
 		initOpenCLGlobal(std::vector<W2XConvProcessor> *proc_list)
 	{
 #ifdef _WIN32
-		handle = LoadLibrary("OpenCL.dll");
+		handle = LoadLibraryA("OpenCL.dll");
 #elif defined __APPLE__
 		handle = dlopen("/System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL", RTLD_LAZY);
 #define GetProcAddress dlsym
@@ -292,7 +292,7 @@ namespace w2xc {
 		char *self_path = (char*)malloc(path_len + 1);
 		DWORD len;
 		while (1) {
-			len = GetModuleFileName(NULL, self_path, (DWORD) path_len);
+			len = GetModuleFileNameA(NULL, self_path, (DWORD) path_len);
 			if (len > 0 && len != path_len) {
 				break;
 			}
@@ -300,8 +300,8 @@ namespace w2xc {
 			path_len *= 2;
 			self_path = (char*)realloc(self_path, path_len + 1);
 		}
-		WIN32_FIND_DATA self_st;
-		HANDLE finder = FindFirstFile(self_path, &self_st);
+		WIN32_FIND_DATAA self_st;
+		HANDLE finder = FindFirstFileA(self_path, &self_st);
 		FindClose(finder);
 
 		for (int si = len - 1; si >= 0; si--) {
@@ -335,8 +335,8 @@ namespace w2xc {
 			}
 			size_t bin_sz = bin_st.st_size;
 #else
-			WIN32_FIND_DATA bin_st;
-			HANDLE finder = FindFirstFile(bin_path.c_str(), &bin_st);
+			WIN32_FIND_DATAA bin_st;
+			HANDLE finder = FindFirstFileA(bin_path.c_str(), &bin_st);
 			FindClose(finder);
 
 			bool old = false;

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -1472,6 +1472,235 @@ w2xconv_convert_file(struct W2XConv *conv,
 }
 
 
+#if defined(WIN32) && defined(UNICODE)
+
+cv::Mat read_imageW(const WCHAR* filepath, int flags=cv::IMREAD_COLOR)
+{
+    FILE* fp = _wfopen(filepath, L"rb");
+    if (!fp)
+    {
+        return cv::Mat::zeros(1, 1, CV_8U);
+    }
+    fseek(fp, 0, SEEK_END);
+    long end = ftell(fp);
+    char* buf = new char[end];
+    fseek(fp, 0, SEEK_SET);
+    size_t n = fread(buf, 1, end, fp);
+    cv::_InputArray arr(buf, end);
+    cv::Mat img = cv::imdecode(arr, flags);
+    delete[] buf;
+    fclose(fp);
+    return img;
+}
+
+bool write_imageW(const WCHAR* filepath, cv::Mat& img, std::vector<int> param = std::vector<int>(0))
+{
+	std::vector<uchar> buf;
+	std::wstring ext_w = std::wstring(filepath);
+	std::string ext;
+	ext.assign(ext_w.begin(), ext_w.end());
+	ext = ext.substr(ext.find_last_of("."));
+	
+	if(!cv::imencode(ext.c_str(),img, buf, param))
+		return false;
+	
+    FILE* fp = _wfopen(filepath, L"wb+");
+    if (!fp)
+        return false;
+	fwrite(buf.data(), sizeof(unsigned char), buf.size(), fp);
+    fclose(fp);
+    return true;
+}
+
+int
+w2xconv_convert_fileW(struct W2XConv *conv,
+		     const WCHAR *dst_path,
+                     const WCHAR *src_path,
+                     int denoise_level,
+                     double scale,
+		     int blockSize)
+{
+	double time_start = getsec();
+	bool is_rgb = (conv->impl->scale2_models[0]->getNInputPlanes() == 3);
+
+	FILE *png_fp = NULL;
+	png_fp = _wfopen(src_path, L"rb");
+
+	if (png_fp == NULL) {
+		setPathError(conv, W2XCONV_ERROR_IMREAD_FAILED, "src_path");
+		return -1;
+	}
+
+	bool png_rgb;
+	//Background colour
+	//float3 background(1.0f, 1.0f, 1.0f);
+	w2xconv_rgb_float3 background;
+	background.r = background.g = background.b = 1.0f;
+	get_png_background_colour(png_fp, &png_rgb, &background);
+
+	if (png_fp) {
+		fclose(png_fp);
+		png_fp = NULL;
+	}
+
+	cv::Mat image_src, image_dst;
+
+	/*
+	 * IMREAD_COLOR                 : always BGR
+	 * IMREAD_UNCHANGED + png       : BGR or BGRA
+	 * IMREAD_UNCHANGED + otherwise : ???
+	 */
+	if (png_rgb) {
+		image_src = read_imageW(src_path, cv::IMREAD_UNCHANGED);
+	} else {
+		image_src = read_imageW(src_path, cv::IMREAD_COLOR);
+	}
+	enum w2xc::image_format fmt;
+
+	int src_depth = CV_MAT_DEPTH(image_src.type());
+	int src_cn = CV_MAT_CN(image_src.type());
+	cv::Mat image = cv::Mat(image_src.size(), CV_32FC3);
+	cv::Mat alpha;
+
+	if (is_rgb) {
+		if (png_rgb) {
+			if (src_cn == 4) {
+				// save alpha
+				alpha = cv::Mat(image_src.size(), CV_32FC1);
+				if (src_depth == CV_16U) {
+					preproc_rgba2rgb<unsigned short, 65535, 2, 0>(&image, &alpha, &image_src,
+										      background.r, background.g, background.b);
+				} else {
+					preproc_rgba2rgb<unsigned char, 255, 2, 0>(&image, &alpha, &image_src,
+										   background.r, background.g, background.b);
+				}
+			} else {
+				preproc_rgb2rgb<unsigned short, 65535, 2, 0>(&image, &image_src);
+			}
+		} else {
+			preproc_rgb2rgb<unsigned char, 255, 2, 0>(&image, &image_src);
+		}
+		fmt = w2xc::IMAGE_RGB_F32;
+	} else {
+		if (png_rgb) {
+			if (src_cn == 4) {
+				// save alpha
+				alpha = cv::Mat(image_src.size(), CV_32FC1);
+				if (src_depth == CV_16U) {
+					preproc_rgba2yuv<unsigned short, 65535, 2, 0>(&image, &alpha, &image_src,
+										      background.r, background.g, background.b);
+				} else {
+					preproc_rgba2yuv<unsigned char, 255, 2, 0>(&image, &alpha, &image_src,
+										   background.r, background.g, background.b);
+				}
+			} else {
+				preproc_rgb2yuv<unsigned short, 65535, 2, 0>(&image, &image_src);
+			}
+		} else {
+			preproc_rgb2yuv<unsigned char, 255, 2, 0>(&image, &image_src);
+		}
+
+		fmt = w2xc::IMAGE_Y;
+	}
+	image_src.release();
+
+	if (denoise_level != -1) {
+		apply_denoise(conv, image, denoise_level, blockSize, fmt);
+	}
+
+	if (scale != 1.0) {
+		// calculate iteration times of 2x scaling and shrink ratio which will use at last
+		int iterTimesTwiceScaling = static_cast<int>(std::ceil(std::log2(scale)));
+		double shrinkRatio = 0.0;
+		if (static_cast<int>(scale)
+		    != std::pow(2, iterTimesTwiceScaling))
+		{
+			shrinkRatio = scale / std::pow(2.0, static_cast<double>(iterTimesTwiceScaling));
+		}
+
+		apply_scale(conv, image, iterTimesTwiceScaling, blockSize, fmt);
+
+		if (shrinkRatio != 0.0) {
+			cv::Size lastImageSize = image.size();
+			lastImageSize.width =
+				static_cast<int>(static_cast<double>(lastImageSize.width
+								     * shrinkRatio));
+			lastImageSize.height =
+				static_cast<int>(static_cast<double>(lastImageSize.height
+								     * shrinkRatio));
+			cv::resize(image, image, lastImageSize, 0, 0, cv::INTER_LINEAR);
+		}
+	}
+
+	bool dst_png = false;
+	{
+		size_t len = wcslen(dst_path);
+		if (len >= 4) {
+			if (towlower(dst_path[len-4]) == L'.' &&
+			    towlower(dst_path[len-3]) == L'p' &&
+			    towlower(dst_path[len-2]) == L'n' &&
+			    towlower(dst_path[len-1]) == L'g')
+			{
+				dst_png = true;
+			}
+		}
+	}
+
+	if (alpha.empty() || !dst_png) {
+		image_dst = cv::Mat(image.size(), CV_MAKETYPE(src_depth,3));
+
+		if (is_rgb) {
+			if (src_depth == CV_16U) {
+				postproc_rgb2rgb<unsigned short, 65535, 2, 0>(&image_dst, &image);
+			} else {
+				postproc_rgb2rgb<unsigned char, 255, 2, 0>(&image_dst, &image);
+			}
+		} else {
+			if (src_depth == CV_16U) {
+				postproc_yuv2rgb<unsigned short, 65535, 0, 2>(&image_dst, &image);
+			} else {
+				postproc_yuv2rgb<unsigned char, 255, 0, 2>(&image_dst, &image);
+			}
+		}
+	} else {
+		image_dst = cv::Mat(image.size(), CV_MAKETYPE(src_depth,4));
+
+		if (image.size() != alpha.size()) {
+			cv::resize(alpha, alpha, image.size(), 0, 0, cv::INTER_LINEAR);
+		}
+
+		if (is_rgb) {
+			if (src_depth == CV_16U) {
+				postproc_rgb2rgba<unsigned short, 65535, 2, 0>(&image_dst, &image, &alpha, background.r, background.g, background.b);
+			} else {
+				postproc_rgb2rgba<unsigned char, 255, 2, 0>(&image_dst, &image, &alpha, background.r, background.g, background.b);
+			}
+		} else {
+			if (src_depth == CV_16U) {
+				postproc_yuv2rgba<unsigned short, 65535, 0, 2>(&image_dst, &image, &alpha, background.r, background.g, background.b);
+			} else {
+				postproc_yuv2rgba<unsigned char, 255, 0, 2>(&image_dst, &image, &alpha, background.r, background.g, background.b);
+			}
+		}
+	}
+
+	if (!write_imageW(dst_path, image_dst)) {
+		setPathError(conv,
+			     W2XCONV_ERROR_IMWRITE_FAILED,
+			     "dst_path");
+		return -1;
+	}
+
+	double time_end = getsec();
+
+	conv->flops.process_sec += time_end - time_start;
+
+	//printf("== %f == \n", conv->impl->env.transfer_wait);
+
+	return 0;
+}
+#endif
+
 
 static void
 convert_mat(struct W2XConv *conv,

--- a/src/w2xconv.h
+++ b/src/w2xconv.h
@@ -17,6 +17,10 @@ extern "C" {
 #define W2XCONV_EXPORT __declspec(dllimport)
 #endif
 
+#ifdef UNICODE
+#include <Windows.h>
+#endif
+
 
 #else
 
@@ -197,6 +201,15 @@ W2XCONV_EXPORT int w2xconv_convert_file(struct W2XConv *conv,
 					int denoise_level, /* -1:none, 0:L0 denoise, 1:L1 denoise, 2:L2 denoise, 3:L3 denoise  */
 					double scale,
 					int block_size);
+
+#if defined(WIN32) && defined(UNICODE)		
+W2XCONV_EXPORT int w2xconv_convert_fileW(struct W2XConv *conv,
+					const WCHAR *dst_path,
+					const WCHAR *src_path,
+					int denoise_level, /* -1:none, 0:L0 denoise, 1:L1 denoise, 2:L2 denoise, 3:L3 denoise  */
+					double scale,
+					int block_size);
+#endif			
 
 W2XCONV_EXPORT int w2xconv_convert_rgb(struct W2XConv *conv,
 				       unsigned char *dst, size_t dst_step_byte, /* rgb24 (src_w*ratio, src_h*ratio) */


### PR DESCRIPTION
It supports unicode_named file conversion (test level).
It only tested in Windows / FORCE-AMD mode.

How to build: add -DBUILD_UNICODE to cmake parameter

How to use: waifu2x-converter-cpp.exe "inputfile" "outputfile"

It needs test in Linux (I use -A functions like to prevent errors not using unicode FindFirstFileA)

TCLAP does not support unicode, we have to implement all parameters setting in c++ code.

Note: this source file is not looks clean and need to improve. 