### PR TITLE
Code path normalize opencv

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1053,14 +1053,16 @@ int main(int argc, char** argv) {
 		//Build files list
 		std::deque<fs::path> files_list;
 		std::cout << "We're going to be operating in a directory. dir:" << fs::absolute(input) << std::endl;
+
+//		TODO: Use a variant instead of so much repeated code
 		if (recursive_directory_iterator) {
 			for (auto & inputFile : fs::recursive_directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {
-					if(validate_format_extension(inputFile.filename())){
+					if(validate_format_extension(inputFile.path().filename())){
 						files_list.push_back(inputFile);
 					}
 					else {
-						std::cout << "Skipping file '" << inputFile.filename() <<  "' for having an unsupported file extension" << std::endl;
+						std::cout << "Skipping file '" << inputFile.path().filename() <<  "' for having an unsupported file extension" << std::endl;
 						continue;
 					}
 				}
@@ -1069,11 +1071,11 @@ int main(int argc, char** argv) {
 		else {
 			for (auto & inputFile : fs::directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {
-					if(validate_format_extension(inputFile.filename())){
+					if(validate_format_extension(inputFile.path().filename())){
 						files_list.push_back(inputFile);
 					}
 					else {
-						std::cout << "Skipping file '" << inputFile.filename() <<  "' for having an unsupported file extension" << std::endl;
+						std::cout << "Skipping file '" << inputFile.path().filename() <<  "' for having an unsupported file extension" << std::endl;
 						continue;
 					}
 				}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1058,11 +1058,12 @@ int main(int argc, char** argv) {
 		if (recursive_directory_iterator) {
 			for (auto & inputFile : fs::recursive_directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {
-					if(validate_format_extension(inputFile.path().filename())){
+					if(validate_format_extension(inputFile.path().extension().native().substr(1))){
 						files_list.push_back(inputFile);
 					}
 					else {
-						std::cout << "Skipping file '" << inputFile.path().filename() <<  "' for having an unsupported file extension" << std::endl;
+						std::cout << "Skipping file '" << inputFile.path().filename().native() <<
+								"' for having an unsupported file extension (" << inputFile.path().extension().native().substr(1) << ")" << std::endl;
 						continue;
 					}
 				}
@@ -1071,11 +1072,12 @@ int main(int argc, char** argv) {
 		else {
 			for (auto & inputFile : fs::directory_iterator(input)) {
 				if (!fs::is_directory(inputFile)) {
-					if(validate_format_extension(inputFile.path().filename())){
+					if(validate_format_extension(inputFile.path().extension().native().substr(1))){
 						files_list.push_back(inputFile);
 					}
 					else {
-						std::cout << "Skipping file '" << inputFile.path().filename() <<  "' for having an unsupported file extension" << std::endl;
+						std::cout << "Skipping file '" << inputFile.path().filename().native() <<
+								"' for having an unsupported file extension (" << inputFile.path().extension().native().substr(1) << ")" << std::endl;
 						continue;
 					}
 				}
@@ -1086,12 +1088,10 @@ int main(int argc, char** argv) {
 		double timeAvg = 0.0;
 		int files_count = static_cast<int>(files_list.size());
 		for (auto &fn : files_list) {
-
 			++numFilesProcessed;
 			double time_file_start = getsec();
 
 			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << (verbose ? "\n" : " Ok. ");
-
 
 			try {
 				convert_file(convInfo, fn, output);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -396,7 +396,7 @@ void convert_fileW(ConvInfo info, fs::path inputName, fs::path output) {
 
 	
 //check for opencv formats
-void check_opencv_formats()
+void parse_supported_cv_formats()
 {
 	#ifndef HAVE_OPENCV
 		// Only default formats are supported
@@ -580,13 +580,13 @@ int wmain(void){
 			return 0;
 		}
 		else if ((wcscmp(argv_w[ai], L"--list-opencv-formats") == 0)) {
-			check_opencv_formats();
 			debug_show_opencv_formats();
+			parse_supported_cv_formats();
 			return 0;
 		}
 	}
 	
-	check_opencv_formats();
+	parse_supported_cv_formats();
 	
 	// definition of command line arguments
 	TCLAP::CmdLine cmd("waifu2x OpenCV Fork - https://github.com/DeadSix27/waifu2x-converter-cpp", ' ', std::string(GIT_TAG) + " (" + GIT_BRANCH + "-" + GIT_COMMIT_HASH + ")", true);
@@ -859,13 +859,13 @@ int main(int argc, char** argv) {
 			return 0;
 		}
 		if (strcmp(argv[ai], "--list-opencv-formats") == 0) {
-			check_opencv_formats();
 			debug_show_opencv_formats();
+			parse_supported_cv_formats();
 			return 0;
 		}
 	}
 	
-	check_opencv_formats();
+	parse_supported_cv_formats();
 
 	// definition of command line arguments
 	TCLAP::CmdLine cmd("waifu2x OpenCV Fork - https://github.com/DeadSix27/waifu2x-converter-cpp", ' ', std::string(GIT_TAG) + " (" + GIT_BRANCH + "-" + GIT_COMMIT_HASH + ")", true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -468,7 +468,7 @@ void parse_supported_cv_formats()
 	// OpenEXR Image Files
 	opencv_formats["EXR"] = true;
 }
-void debug_show_opencv_formats()
+void display_supported_formats()
 {
 
 	std::cout << "This is a list of supported formats."
@@ -586,9 +586,9 @@ int wmain(void){
 			dump_procs();
 			return 0;
 		}
-			debug_show_opencv_formats();
 		else if ((wcscmp(argv_w[ai], L"--list-opencv-formats") == 0) || (wcscmp(argv_w[ai], L"--list-supported-formats") == 0)) {
 			parse_supported_cv_formats();
+			display_supported_formats();
 			return 0;
 		}
 	}
@@ -866,9 +866,9 @@ int main(int argc, char** argv) {
 			dump_procs();
 			return 0;
 		}
-			debug_show_opencv_formats();
 		if (strcmp(argv[ai], "--list-opencv-formats") == 0 || strcmp(argv[ai], "--list-supported-formats") == 0) {
 			parse_supported_cv_formats();
+			display_supported_formats();
 			return 0;
 		}
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,7 +470,14 @@ void parse_supported_cv_formats()
 }
 void debug_show_opencv_formats()
 {
-	std::cout << "This is a list of supported formats, it depends on which formats opencv has been built with." << std::endl ;
+
+	std::cout << "This is a list of supported formats."
+	#ifdef HAVE_OPENCV
+			" This list depends on which formats opencv has been built with."
+	#else
+			" OpenCV is disabled (recompile to enable), so only the default formats can be used"
+	#endif
+			 << std::endl ;
 	for (auto const& x : opencv_formats)
 	{
 		std::cout << "\t" << std::setw(4) << x.first << " -> " << (x.second ? "Yes" : "No") << std::endl ;
@@ -579,8 +586,8 @@ int wmain(void){
 			dump_procs();
 			return 0;
 		}
-		else if ((wcscmp(argv_w[ai], L"--list-opencv-formats") == 0)) {
 			debug_show_opencv_formats();
+		else if ((wcscmp(argv_w[ai], L"--list-opencv-formats") == 0) || (wcscmp(argv_w[ai], L"--list-supported-formats") == 0)) {
 			parse_supported_cv_formats();
 			return 0;
 		}
@@ -654,12 +661,13 @@ int wmain(void){
 	TCLAP::ValueArg<int> cmdPngCompression("c", "png-compression", "Set PNG compression level (0-9), 9 = Max compression (slowest & smallest)",
 		false, 5, "0-9", cmd);
 		
-	TCLAP::ValueArg<std::string> cmdOutputFormat("f", "output-format", "The format used when running in recursive/folder mode\nSee --list-opencv-formats for a list of supported formats/extensions.",
+	TCLAP::ValueArg<std::string> cmdOutputFormat("f", "output-format", "The format used when running in recursive/folder mode\nSee --list-supported-formats for a list of supported formats/extensions.",
 		false, "png", "png,jpg,webp,...", cmd);
 		
 	TCLAP::SwitchArg cmdListProcessor("l", "list-processor", "dump processor list", cmd, false);
 	
-	TCLAP::SwitchArg showOpenCVFormats("", "list-opencv-formats", "dump opencv supported format list", cmd, false);
+	TCLAP::SwitchArg showOpenCVFormats_deprecated("", "list-opencv-formats", " (deprecated. Use --list-supported-formats) dump opencv supported format list", cmd, false);
+	TCLAP::SwitchArg showOpenCVFormats("", "list-supported-formats", "dump currently supported format list", cmd, false);
 
 	// definition of command line argument : end
 
@@ -685,7 +693,7 @@ int wmain(void){
 		std::exit(-1);
 	}
 	if(validate_format_extension(cmdOutputFormat.getValue())==false){
-		printf("Unsupported output extension: %s\nUse option --list-opencv-formats to see a list of supported formats", cmdOutputFormat.getValue().c_str());
+		printf("Unsupported output extension: %s\nUse option --list-supported-formats to see a list of supported formats", cmdOutputFormat.getValue().c_str());
 		std::exit(-1);
 	}
 	
@@ -858,8 +866,8 @@ int main(int argc, char** argv) {
 			dump_procs();
 			return 0;
 		}
-		if (strcmp(argv[ai], "--list-opencv-formats") == 0) {
 			debug_show_opencv_formats();
+		if (strcmp(argv[ai], "--list-opencv-formats") == 0 || strcmp(argv[ai], "--list-supported-formats") == 0) {
 			parse_supported_cv_formats();
 			return 0;
 		}
@@ -933,12 +941,13 @@ int main(int argc, char** argv) {
 	TCLAP::ValueArg<int> cmdPngCompression("c", "png-compression", "Set PNG compression level (0-9), 9 = Max compression (slowest & smallest)",
 		false, 5, "0-9", cmd);
 		
-	TCLAP::ValueArg<std::string> cmdOutputFormat("f", "output-format", "The format used when running in recursive/folder mode\nSee --list-opencv-formats for a list of supported formats/extensions.",
+	TCLAP::ValueArg<std::string> cmdOutputFormat("f", "output-format", "The format used when running in recursive/folder mode\nSee --list-supported-formats for a list of supported formats/extensions.",
 		false, "png", "png,jpg,webp,...", cmd);
 	
 	TCLAP::SwitchArg cmdListProcessor("l", "list-processor", "dump processor list", cmd, false);
 	
-	TCLAP::SwitchArg showOpenCVFormats("", "list-opencv-formats", "dump opencv supported format list", cmd, false);
+	TCLAP::SwitchArg showOpenCVFormats_deprecated("", "list-opencv-formats", " (deprecated. Use --list-supported-formats) dump opencv supported format list", cmd, false);
+	TCLAP::SwitchArg showOpenCVFormats("", "list-supported-formats", "dump currently supported format list", cmd, false);
 
 	// definition of command line argument : end
 
@@ -964,7 +973,7 @@ int main(int argc, char** argv) {
 		std::exit(-1);
 	}
 	if(validate_format_extension(cmdOutputFormat.getValue())==false){
-		printf("Unsupported output extension: %s\nUse option --list-opencv-formats to see a list of supported formats", cmdOutputFormat.getValue().c_str());
+		printf("Unsupported output extension: %s\nUse option --list-supported-formats to see a list of supported formats", cmdOutputFormat.getValue().c_str());
 		std::exit(-1);
 	}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ void check_for_errors(W2XConv* converter, int error) {
 }
 
 
-std::map<std::string,bool> opencv_formats = {
+std::map<std::string,bool> supported_formats = {
 	// Windows Bitmaps
 	{"BMP",  false},
 	{"DIB",  false},
@@ -207,8 +207,8 @@ bool validate_format_extension(std::string extension) {
 	for(std::string::iterator it = extension.begin(); it != extension.end(); ++it){
 		*it = std::toupper(*it);
 	}
-	auto index = opencv_formats.find(extension);
-	if (index != opencv_formats.end()) {
+	auto index = supported_formats.find(extension);
+	if (index != supported_formats.end()) {
 		return index->second;
 	}
 	return false;
@@ -419,54 +419,54 @@ void parse_supported_cv_formats()
 			// Portable Network Graphics
 			if ((strings[0] == "PNG"))
 			{
-				opencv_formats["PNG"] = strings[1] != "NO";
+				supported_formats["PNG"] = strings[1] != "NO";
 			}
 			// JPEG Files
 			else if ((strings[0] == "JPEG"))
 			{
-				opencv_formats["JPEG"] = (strings[1] != "NO");
-				opencv_formats["JPG"] = (strings[1] != "NO");
-				opencv_formats["JPE"] = (strings[1] != "NO");
+				supported_formats["JPEG"] = (strings[1] != "NO");
+				supported_formats["JPG"] = (strings[1] != "NO");
+				supported_formats["JPE"] = (strings[1] != "NO");
 			}
 			// JPEG 2000 Files
 			else if ((strings[0] == "JPEG 2000") && (strings[1] != "NO"))
 			{
-				opencv_formats["JP2"] = true;
+				supported_formats["JP2"] = true;
 			}
 			// WebP
 			else if ((strings[0] == "WEBP") && (strings[1] != "NO"))
 			{
-				opencv_formats["WEBP"] = true;
+				supported_formats["WEBP"] = true;
 			}
 			// TIFF Files
 			else if ((strings[0] == "TIFF") && (strings[1] != "NO"))
 			{
-				opencv_formats["TIF"] = true;
-				opencv_formats["TIFF"] = true;
+				supported_formats["TIF"] = true;
+				supported_formats["TIFF"] = true;
 			}
 		}
 	}
 	// Windows Bitmaps (Always Supported)
-	opencv_formats["BMP"] = true;
-	opencv_formats["DIB"] = true;
+	supported_formats["BMP"] = true;
+	supported_formats["DIB"] = true;
 	
 	// Portable Image Format (Always Supported)
-	opencv_formats["PBM"] = true;
-	opencv_formats["PGM"] = true;
-	opencv_formats["PPM"] = true;
-	opencv_formats["PXM"] = true;
-	opencv_formats["PNM"] = true;
+	supported_formats["PBM"] = true;
+	supported_formats["PGM"] = true;
+	supported_formats["PPM"] = true;
+	supported_formats["PXM"] = true;
+	supported_formats["PNM"] = true;
 	
 	// Sun Rasters (Always Supported)
-	opencv_formats["SR"] = true;
-	opencv_formats["RAS"] = true;
+	supported_formats["SR"] = true;
+	supported_formats["RAS"] = true;
 	
 	// Radiance HDR (Always Supported)
-	opencv_formats["HDR"] = true;
-	opencv_formats["PIC"] = true;
+	supported_formats["HDR"] = true;
+	supported_formats["PIC"] = true;
 	
 	// OpenEXR Image Files
-	opencv_formats["EXR"] = true;
+	supported_formats["EXR"] = true;
 }
 void display_supported_formats()
 {
@@ -478,7 +478,7 @@ void display_supported_formats()
 			" OpenCV is disabled (recompile to enable), so only the default formats can be used"
 	#endif
 			 << std::endl ;
-	for (auto const& x : opencv_formats)
+	for (auto const& x : supported_formats)
 	{
 		std::cout << "\t" << std::setw(4) << x.first << " -> " << (x.second ? "Yes" : "No") << std::endl ;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,11 +262,9 @@ std::string generate_output_location(std::string inputFileName, std::string outp
 	else if (lastSlashPos == std::string::npos || lastDotPos > lastSlashPos) {
 		//We may have a regular output file here or something went wrong.
 		//outputFileName is already what it should be thus nothing needs to be done.
-		#ifdef HAVE_OPENCV
 		if(validate_format_extension(outputFileName.substr(lastDotPos+1))==false){
 			throw std::runtime_error("Unsupported output extension. outputFileName:" + outputFileName + " extension:" +outputFileName.substr(lastDotPos+1));
 		}
-		#endif
 	}
 	else {
 		throw std::runtime_error("An unknown 'outputFileName' has been inserted into generate_output_location. outputFileName: " + outputFileName);
@@ -328,11 +326,9 @@ std::wstring generate_output_location(std::wstring inputFileName, std::wstring o
 	else if (lastSlashPos == std::wstring::npos || lastDotPos > lastSlashPos) {
 		//We may have a regular output file here or something went wrong.
 		//outputFileName is already what it should be thus nothing needs to be done.
-		#ifdef HAVE_OPENCV
 		if(validate_format_extension(to_mbs(outputFileName.substr(lastDotPos+1)))==false){
 			throw std::runtime_error("Unsupported output extension.");
 		}
-		#endif
 	}
 	else {
 		throw std::runtime_error("An unknown 'outputFileName' has been inserted into generate_output_location.");
@@ -402,6 +398,11 @@ void convert_fileW(ConvInfo info, fs::path inputName, fs::path output) {
 //check for opencv formats
 void check_opencv_formats()
 {
+	#ifndef HAVE_OPENCV
+		// Only default formats are supported
+		return;
+	#endif
+
 	std::istringstream iss(cv::getBuildInformation());
 
 	for (std::string line; std::getline(iss, line); )
@@ -578,18 +579,14 @@ int wmain(void){
 			dump_procs();
 			return 0;
 		}
-		#ifdef HAVE_OPENCV
 		else if ((wcscmp(argv_w[ai], L"--list-opencv-formats") == 0)) {
 			check_opencv_formats();
 			debug_show_opencv_formats();
 			return 0;
 		}
-		#endif
 	}
 	
-	#ifdef HAVE_OPENCV
 	check_opencv_formats();
-	#endif
 	
 	// definition of command line arguments
 	TCLAP::CmdLine cmd("waifu2x OpenCV Fork - https://github.com/DeadSix27/waifu2x-converter-cpp", ' ', std::string(GIT_TAG) + " (" + GIT_BRANCH + "-" + GIT_COMMIT_HASH + ")", true);
@@ -662,9 +659,7 @@ int wmain(void){
 		
 	TCLAP::SwitchArg cmdListProcessor("l", "list-processor", "dump processor list", cmd, false);
 	
-	#ifdef HAVE_OPENCV
 	TCLAP::SwitchArg showOpenCVFormats("", "list-opencv-formats", "dump opencv supported format list", cmd, false);
-	#endif
 
 	// definition of command line argument : end
 
@@ -689,12 +684,10 @@ int wmain(void){
 		std::cout << "Error: JPEG & WebP Compression quality range is 0-100, 100 having the best quality but largest file size." << std::endl;
 		std::exit(-1);
 	}
-	#ifdef HAVE_OPENCV
 	if(validate_format_extension(cmdOutputFormat.getValue())==false){
 		printf("Unsupported output extension: %s\nUse option --list-opencv-formats to see a list of supported formats", cmdOutputFormat.getValue().c_str());
 		std::exit(-1);
 	}
-	#endif
 	
 	//We need to do this conversion because using a TCLAP::ValueArg<fs::path> can not handle spaces.
 	fs::path input = inputFileName;
@@ -865,18 +858,14 @@ int main(int argc, char** argv) {
 			dump_procs();
 			return 0;
 		}
-		#ifdef HAVE_OPENCV
 		if (strcmp(argv[ai], "--list-opencv-formats") == 0) {
 			check_opencv_formats();
 			debug_show_opencv_formats();
 			return 0;
 		}
-		#endif
 	}
 	
-	#ifdef HAVE_OPENCV
 	check_opencv_formats();
-	#endif
 
 	// definition of command line arguments
 	TCLAP::CmdLine cmd("waifu2x OpenCV Fork - https://github.com/DeadSix27/waifu2x-converter-cpp", ' ', std::string(GIT_TAG) + " (" + GIT_BRANCH + "-" + GIT_COMMIT_HASH + ")", true);
@@ -949,9 +938,7 @@ int main(int argc, char** argv) {
 	
 	TCLAP::SwitchArg cmdListProcessor("l", "list-processor", "dump processor list", cmd, false);
 	
-	#ifdef HAVE_OPENCV
 	TCLAP::SwitchArg showOpenCVFormats("", "list-opencv-formats", "dump opencv supported format list", cmd, false);
-	#endif
 
 	// definition of command line argument : end
 
@@ -976,12 +963,10 @@ int main(int argc, char** argv) {
 		std::cout << "Error: JPEG & WebP Compression quality range is 0-100, 100 having the best quality but largest file size." << std::endl;
 		std::exit(-1);
 	}
-	#ifdef HAVE_OPENCV
 	if(validate_format_extension(cmdOutputFormat.getValue())==false){
 		printf("Unsupported output extension: %s\nUse option --list-opencv-formats to see a list of supported formats", cmdOutputFormat.getValue().c_str());
 		std::exit(-1);
 	}
-	#endif
 
 	//We need to do this conversion because using a TCLAP::ValueArg<fs::path> can not handle spaces.
 	fs::path input = cmdInput.getValue();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -473,11 +473,12 @@ void display_supported_formats()
 
 	std::cout << "This is a list of supported formats."
 	#ifdef HAVE_OPENCV
-			" This list depends on which formats opencv has been built with."
+			" OpenCV is available, so this list depends on which formats opencv has been built with."
 	#else
-			" OpenCV is disabled (recompile to enable), so only the default formats can be used"
+			" OpenCV is unavailable (recompile to enable), so only the default formats can be used"
 	#endif
 			 << std::endl ;
+
 	for (auto const& x : supported_formats)
 	{
 		std::cout << "\t" << std::setw(4) << x.first << " -> " << (x.second ? "Yes" : "No") << std::endl ;


### PR DESCRIPTION
related to #71,
1. Reduce the amount of name references to opencv on code that is, in practice, not dependent on opencv existing.
2. Reduce the amount of `#ifdef` related to opencv to the ones actually needed (3 instances)