### PR TITLE
Add an option --keep-kernel to force to keep the kernel on OpenCL.

### DIFF
--- a/src/filters.hpp
+++ b/src/filters.hpp
@@ -10,7 +10,7 @@ namespace w2xc {
 void initOpenCLGlobal(std::vector<W2XConvProcessor> *proc_list);
 void initCUDAGlobal(std::vector<W2XConvProcessor> *proc_list);
 
-bool initOpenCL(W2XConv *c, ComputeEnv *env, W2XConvProcessor *proc);
+bool initOpenCL(W2XConv *c, ComputeEnv *env, W2XConvProcessor *proc, bool keep_kernel /*= false*/);
 void finiOpenCL(ComputeEnv *env);
 bool initCUDA(ComputeEnv *env, int dev_id);
 void finiCUDA(ComputeEnv *env);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -606,8 +606,7 @@ int wmain(void){
 	TCLAP::ValueArg<bool> cmdRecursiveDirectoryIterator("r", "recursive-directory",
 		"Search recursively through directories to find more images to process.\nIf this is set to 0 it will only check in the directory specified if the input is a directory instead of an image.\nYou mustn't supply this argument with something other than 0 or 1.", false,
 		0, "bool", cmd);
-
-
+    
 	TCLAP::SwitchArg cmdQuiet("s", "silent", "Enable silent mode.", cmd, false);
 
 	std::vector<std::string> cmdModeConstraintV;
@@ -723,7 +722,7 @@ int wmain(void){
 		converter = w2xconv_init_with_processor(proc, cmdNumberOfJobs.getValue(), verbose);
 	}
 	else {
-		converter = w2xconv_init(gpu, cmdNumberOfJobs.getValue(), verbose);
+		converter = w2xconv_init(gpu, cmdNumberOfJobs.getValue(), verbose, /*keep_kernel=*/ false);
 	}
 	
 	int imwrite_params[6];
@@ -932,6 +931,8 @@ int main(int argc, char** argv) {
 	TCLAP::SwitchArg cmdForceOpenCL("", "force-OpenCL",
 		"force to use OpenCL on Intel Platform",
 		cmd, false);
+    
+    TCLAP::SwitchArg cmdKeepKernel("k", "keep-kernel", "shall we keep OpenCL kernel", cmd, false);
 
 	TCLAP::SwitchArg cmdDisableGPU("", "disable-gpu", "disable GPU", cmd, false);
 
@@ -1005,12 +1006,13 @@ int main(int argc, char** argv) {
 	w2xconv_get_processor_list(&num_proc);
 	int proc = cmdTargetProcessor.getValue();
 	bool verbose = !cmdQuiet.getValue();
+    bool keep_kernel = cmdKeepKernel.getValue();
 
 	if (proc != -1 && proc < num_proc) {
-		converter = w2xconv_init_with_processor(proc, cmdNumberOfJobs.getValue(), verbose);
+		converter = w2xconv_init_with_processor(proc, cmdNumberOfJobs.getValue(), verbose, false);
 	}
 	else {
-		converter = w2xconv_init(gpu, cmdNumberOfJobs.getValue(), verbose);
+		converter = w2xconv_init(gpu, cmdNumberOfJobs.getValue(), verbose, keep_kernel);
 	}
 	
 	int imwrite_params[6];

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -355,18 +355,20 @@ select_device(enum W2XConvGPUMode gpu)
 W2XConv *
 w2xconv_init(enum W2XConvGPUMode gpu,
              int nJob,
-	     int enable_log)
+             int enable_log,
+             bool keep_kernel = false)
 {
 	global_init();
 
 	int proc_idx = select_device(gpu);
-	return w2xconv_init_with_processor(proc_idx, nJob, enable_log);
+	return w2xconv_init_with_processor(proc_idx, nJob, enable_log, keep_kernel);
 }
 
 struct W2XConv *
 w2xconv_init_with_processor(int processor_idx,
 			    int nJob,
-			    int enable_log)
+			    int enable_log,
+                bool keep_kernel = false)
 {
 	global_init();
 
@@ -386,7 +388,7 @@ w2xconv_init_with_processor(int processor_idx,
 		break;
 
 	case W2XCONV_PROC_OPENCL:
-		r = w2xc::initOpenCL(c, &impl->env, proc);
+		r = w2xc::initOpenCL(c, &impl->env, proc, keep_kernel);
 		if (!r) {
 			return NULL;
 		}

--- a/src/w2xconv.h
+++ b/src/w2xconv.h
@@ -172,11 +172,13 @@ W2XCONV_EXPORT const struct W2XConvProcessor *w2xconv_get_processor_list(size_t 
 
 W2XCONV_EXPORT struct W2XConv *w2xconv_init(enum W2XConvGPUMode gpu,
 					    int njob /* 0 = auto */,
-					    int enable_log);
+					    int enable_log,
+                        bool keep_kernel /*= false shall we keep OpenCL kernel or not */);
 
 W2XCONV_EXPORT struct W2XConv *w2xconv_init_with_processor(int processor_idx,
 							   int njob,
-							   int enable_log);
+							   int enable_log,
+                               bool keep_kernel /* = false shall we keep OpenCL kernel or not */);
 
 /* return negative if failed */
 W2XCONV_EXPORT int w2xconv_load_models(struct W2XConv *conv,

--- a/w32-apps/runbench.c
+++ b/w32-apps/runbench.c
@@ -36,7 +36,7 @@ main(int argc, char **argv)
         num_thread = atoi(argv[3]);
     }
 
-    struct W2XConv *c = w2xconv_init_with_processor(proc, num_thread, 1);
+    struct W2XConv *c = w2xconv_init_with_processor(proc, num_thread, 1, false);
     puts(proc_list[proc].dev_name);
 
     int num_maps[7] = {

--- a/w32-apps/runtest.c
+++ b/w32-apps/runtest.c
@@ -3,7 +3,7 @@
 int
 main(int argc, char **argv)
 {
-    struct W2XConv *c = w2xconv_init(1, 0, 1);
+    struct W2XConv *c = w2xconv_init(1, 0, 1, false);
     const char *models = "models_rgb";
     if (argc >= 2) {
         models = argv[1];

--- a/w32-apps/w2xc.c
+++ b/w32-apps/w2xc.c
@@ -26,7 +26,7 @@ main(int argc, char **argv)
     dst_path[3] = '_';
     strcpy(dst_path+4, argv[1]);
 
-    c = w2xconv_init(W2XCONV_GPU_AUTO, 0, 0);
+    c = w2xconv_init(W2XCONV_GPU_AUTO, 0, 0, false);
     r = w2xconv_load_models(c, "models\\rgb");
     if (r < 0) {
         goto error;


### PR DESCRIPTION
When option is set, the .bin kernel file is never considered to be old, and we try to use it regardless of its status.
This is useful when running very frequent jobs on the same GPU (as waifu2x-converter-cpp kept recreating the kernel, thus losing some precious halfs of seconds - it's non negligible when you run it ~100000 times per day).
I did not find a way to add this option to the help description though.
Oh, and I also added some comments to explain what bizarre functions did (because it's quite messy out there).
Have a nice evening.