### PR TITLE
Slightly improve logging messages

### DIFF
--- a/src/convertRoutine.cpp
+++ b/src/convertRoutine.cpp
@@ -91,7 +91,7 @@ static bool convertWithModelsBasic(W2XConv *conv,
 		int nInputPlanes = models[index]->getNInputPlanes();
 
 		if (enableLog) {
-			std::cout << "Iteration #" << (index + 1) << "(" << nInputPlanes << "->" << nOutputPlanes << ")..." ;
+			printf("Iteration #%d(%3d->%3d)...", (index + 1), nInputPlanes, nOutputPlanes);
 		}
 		double t0 = getsec();
 		if (!models[index]->filter(conv, env, packed_input_buf, packed_output_buf, filterSize)) {
@@ -101,10 +101,10 @@ static bool convertWithModelsBasic(W2XConv *conv,
 		double ops = filterSize.width * filterSize.height * 9.0 * 2.0 * nOutputPlanes * nInputPlanes;
 		double gflops = (ops/(1000.0*1000.0*1000.0)) / (t1-t0);
 		double bytes = (double) filterSize.width * filterSize.height * sizeof(float) * (nOutputPlanes + nInputPlanes);
-		double GBs = (bytes/(1000.0*1000.0*1000.0)) / (t1-t0);
+		double gigabytesPerSec = (bytes/(1000.0*1000.0*1000.0)) / (t1-t0);
 
 		if (enableLog) {
-			std::cout << "(" << (t1-t0)*1000 << "[ms], " << gflops << "[GFLOPS], " << GBs << "[GB/s])" << std::endl;
+			printf("(%.3f[ms], %7.2f[GFLOPS], %8.3f[GB/s])\n", t1-t0, gflops, gigabytesPerSec);
 		}
 		ops_sum += ops;
 
@@ -142,7 +142,7 @@ static bool convertWithModelsBasic(W2XConv *conv,
 
 	if (enableLog) {
 		double gflops = ops_sum/(1000.0*1000.0*1000.0) / (t01-t00);
-		std::cout << "total : " << (t01-t00) << "[sec], " << gflops << "[GFLOPS]" << std::endl;
+		printf("total : %.3f[sec], %07.2f[GFLOPS]\n", t01-t00, gflops);
 	}
 
 	return true;

--- a/src/convertRoutine.cpp
+++ b/src/convertRoutine.cpp
@@ -104,7 +104,7 @@ static bool convertWithModelsBasic(W2XConv *conv,
 		double gigabytesPerSec = (bytes/(1000.0*1000.0*1000.0)) / (t1-t0);
 
 		if (enableLog) {
-			printf("(%.3f[ms], %7.2f[GFLOPS], %8.3f[GB/s])\n", t1-t0, gflops, gigabytesPerSec);
+			printf("(%.5f[ms], %7.2f[GFLOPS], %8.3f[GB/s])\n", t1-t0, gflops, gigabytesPerSec);
 		}
 		ops_sum += ops;
 

--- a/src/convertRoutine.cpp
+++ b/src/convertRoutine.cpp
@@ -370,8 +370,7 @@ static bool convertWithModelsBlockSplit(W2XConv *conv,
 							    curBlockWidth, curBlockHeight));
 
 			if (enableLog) {
-				std::cout << "start process block (" << c << "," << r << ") ..."
-					  << std::endl;
+				std::cout << "start process block (" << (c+1) << "/" << splitColumns << "," << (r+1) << "/" << splitRows << ") ..." << std::endl;
 			}
 
 			int elemSize = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -868,7 +868,7 @@ int main(int argc, char** argv)
 			++numFilesProcessed;
 			double time_file_start = getsec();
 
-			std::cout << "[" << numFilesProcessed << "/" << files_count << "] " << fn.filename() << (verbose ? "\n" : " Ok. ");
+			std::cout << "Processing file [" << numFilesProcessed << "/" << files_count << "] \"" << fn.filename() << "\":" << (verbose ? "\n" : " ");
 
 			try {
 #if defined(WIN32) && defined(UNICODE)
@@ -894,18 +894,20 @@ int main(int argc, char** argv)
 			int el_h = (int) elapsed / (60 * 60);
 			int el_m = (int) (elapsed - el_h * 60 * 60) / 60;
 			int el_s = (int) (elapsed - el_h * 60 * 60 - el_m * 60);
-			std::cout << "Elapsed: ";
+			std::cout << "Done, took: ";
 			if (el_h)
 				std::cout << el_h << "h";
 			if (el_m)
 				std::cout << el_m << "m";
-			std::cout << el_s << "s file: " << time_file << "s avg: " << timeAvg << "s" << std::endl;
+			std::cout << el_s << "s total, file: " << time_file << "s avg: " << timeAvg << "s" << std::endl;
 		}
 
 
 	}
 	else {
 		numFilesProcessed++;
+		double time_file_start = getsec();
+		std::cout << "Processing file [1/1] \"" << input << "\":" << (verbose ? "\n" : " ");
 		try {
 #if defined(WIN32) && defined(UNICODE)
 			convert_fileW(convInfo, input, output);
@@ -917,6 +919,9 @@ int main(int argc, char** argv)
 			numErrors++;
 			std::cout << e.what() << std::endl;
 		}
+		double time_end = getsec();
+		double time_file = time_end - time_file_start;
+		std::cout << "Done, took: " << time_file << "s total, file: " << time_file << "s avg: " << time_file << "s" << std::endl;
 	}
 	
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -870,8 +870,12 @@ int main(int argc, char** argv)
 		for (auto &fn : files_list) {
 			++numFilesProcessed;
 			double time_file_start = getsec();
-
-			std::cout << "Processing file [" << numFilesProcessed << "/" << files_count << "] \"" << fn.filename() << "\":" << (verbose ? "\n" : " ");
+			printf("Processing file [%d/%d] \"%s\":%s",
+				numFilesProcessed,
+				files_count,
+				fn.filename().string().c_str(),
+				(verbose ? "\n" : " ")
+			);
 
 			try {
 #if defined(WIN32) && defined(UNICODE)
@@ -897,12 +901,12 @@ int main(int argc, char** argv)
 			int el_h = (int) elapsed / (60 * 60);
 			int el_m = (int) (elapsed - el_h * 60 * 60) / 60;
 			int el_s = (int) (elapsed - el_h * 60 * 60 - el_m * 60);
-			std::cout << "Done, took: ";
+			printf("Done, took: ");
 			if (el_h)
-				std::cout << el_h << "h";
+				printf("%dh", el_h);
 			if (el_m)
-				std::cout << el_m << "m";
-			std::cout << el_s << "s total, file: " << time_file << "s avg: " << timeAvg << "s" << std::endl;
+				printf("%dm", el_h);
+			printf("%ds total, file: %.3fs avg: %.3fs\n", el_s, time_file, timeAvg);
 		}
 
 
@@ -924,7 +928,7 @@ int main(int argc, char** argv)
 		}
 		double time_end = getsec();
 		double time_file = time_end - time_file_start;
-		std::cout << "Done, took: " << time_file << "s total, file: " << time_file << "s avg: " << time_file << "s" << std::endl;
+		printf("Done, took: %.3fs total, file: %.3fs avg: %.3fs\n", time_file, time_file, time_file);
 	}
 	
 
@@ -935,7 +939,7 @@ int main(int argc, char** argv)
 		double gflops_proc = (converter->flops.flop / (1000.0*1000.0*1000.0)) / converter->flops.filter_sec;
 		double gflops_all = (converter->flops.flop / (1000.0*1000.0*1000.0)) / (time_end - time_start);
 
-		printf("Finished processing %d files%s%fsecs total, filter: %fs. %d files skipped, %d files errored. [GFLOPS: %05f, GFLOPS-Filter: %05f]\n",
+		printf("Finished processing %d files%s%.3fsecs total, filter: %.3fsecs; %d files skipped, %d files errored. [GFLOPS: %7.2f, GFLOPS-Filter: %7.2f]\n",
 			numFilesProcessed,
 			(verbose ? "\nTook: " : ", took: "),
 			(time_end - time_start),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -823,6 +823,7 @@ int main(int argc, char** argv)
 	//This includes errored files.
 	int numFilesProcessed = 0;
 	int numErrors = 0;
+	int numSkipped = 0;
 	
 	if (fs::is_directory(input) == true) {
 		
@@ -840,6 +841,7 @@ int main(int argc, char** argv)
 					else {
 						std::cout << "Skipping file '" << inputFile.path().filename().string() <<
 								"' for having an unsupported file extension (" << ext << ")" << std::endl;
+						numSkipped++;
 						continue;
 					}
 				}
@@ -855,6 +857,7 @@ int main(int argc, char** argv)
 					else {
 						std::cout << "Skipping file '" << inputFile.path().filename().string() <<
 								"' for having an unsupported file extension (" << ext << ")" << std::endl;
+						numSkipped++;
 						continue;
 					}
 				}
@@ -932,13 +935,16 @@ int main(int argc, char** argv)
 		double gflops_proc = (converter->flops.flop / (1000.0*1000.0*1000.0)) / converter->flops.filter_sec;
 		double gflops_all = (converter->flops.flop / (1000.0*1000.0*1000.0)) / (time_end - time_start);
 
-		std::cout << "process successfully done! (all:"
-			<< (time_end - time_start) << "[sec], "
-			<< numFilesProcessed << " [files processed], "
-			<< numErrors << " [files errored], "
-			<< gflops_all << "[GFLOPS], filter:"
-			<< converter->flops.filter_sec
-			<< "[sec], " << gflops_proc << "[GFLOPS])" << std::endl;
+		printf("Finished processing %d files%s%fsecs total, filter: %fs. %d files skipped, %d files errored. [GFLOPS: %05f, GFLOPS-Filter: %05f]\n",
+			numFilesProcessed,
+			(verbose ? "\nTook: " : ", took: "),
+			(time_end - time_start),
+			converter->flops.filter_sec,
+			numSkipped,
+			numErrors,
+			gflops_all,
+			gflops_proc
+		);
 	}
 
 	w2xconv_fini(converter);


### PR DESCRIPTION
Block process log now shows the total rows and columns.

The log messages counting the files now says "Processing" at the start and "Done"  when finished, the instead of previouss "Ok." at the start.

Also single file operations now show the same amount of logging as do folder operations

E.g:
## Before:
Silent:
``` 
K:\w2x\waifu2x-converter-cpp\out\Release>waifu2x-converter-cpp.exe -i 7KMAtWE.jpg -s
CUDA: GeForce RTX 2060
process successfully done! (all:2.93005[sec], 1 [files processed], 0 [files errored], 1994.88[GFLOPS], filter:1.7955[sec], 3255.41[GFLOPS])
```
Verbose:
```
K:\w2x\waifu2x-converter-cpp\out\Release>waifu2x-converter-cpp.exe -i 7KMAtWE.jpg
CUDA: GeForce RTX 2060
start process block (0,0) ...
.............
.............
.............
start process block (4,6) ...
process successfully done! (all:4.2414[sec], 1 [files processed], 0 [files errored], 1378.11[GFLOPS], filter:2.10723[sec], 2773.83[GFLOPS])

K:\w2x\waifu2x-converter-cpp\out\Release>
```
## After:

Silent:
```
K:\w2x\waifu2x-converter-cpp\out\Release>waifu2x-converter-cpp.exe -i 7KMAtWE.jpg -s
CUDA: GeForce RTX 2060
Processing file [1/1] "7KMAtWE.jpg": Done, took: 2.86705s total, file: 2.86705s avg: 2.86705s
process successfully done! (all:2.9237[sec], 1 [files processed], 0 [files errored], 1999.21[GFLOPS], filter:1.80589[sec], 3236.68[GFLOPS])
```
Verbose:
```
K:\w2x\waifu2x-converter-cpp\out\Release>waifu2x-converter-cpp.exe -i 7KMAtWE.jpg
CUDA: GeForce RTX 2060
Processing file [1/1] "7KMAtWE.jpg":
start process block (1/3,1/4) ...
.............
.............
.............
start process block (5/5,7/7) ...
Done, took: 4.21842s total, file: 4.21842s avg: 4.21842s
process successfully done! (all:4.27478[sec], 1 [files processed], 0 [files errored], 1367.34[GFLOPS], filter:2.12139[sec], 2755.32[GFLOPS])
```