### PR TITLE
add steps based logging

### DIFF
--- a/src/convertRoutine.cpp
+++ b/src/convertRoutine.cpp
@@ -370,7 +370,7 @@ static bool convertWithModelsBlockSplit(W2XConv *conv,
 							    curBlockWidth, curBlockHeight));
 
 			if (enableLog) {
-				std::cout << "start process block (" << (c+1) << "/" << splitColumns << "," << (r+1) << "/" << splitRows << ") ..." << std::endl;
+				printf("Processing block, column (%02d/%02d), row (%02d/%02d) ...\n", (c+1), splitColumns, (r+1), splitRows);
 			}
 
 			int elemSize = 0;

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -56,6 +56,8 @@ static void
 global_init2(void)
 {
 	{
+		w2x_total_steps = 0;
+		w2x_current_step = 1;
 		W2XConvProcessor host;
 		host.type = W2XCONV_PROC_HOST;
 		host.sub_type = W2XCONV_PROC_HOST_OPENCV;
@@ -712,19 +714,11 @@ apply_scale(struct W2XConv *conv,
 	struct W2XConvImpl *impl = conv->impl;
 	ComputeEnv *env = &impl->env;
 
-	if (conv->enable_log) {
-		std::cout << "start scaling" << std::endl;
-	}
-
 	// 2x scaling
-	for (int nIteration = 0; nIteration < iterTimesTwiceScaling;
-	     nIteration++) {
-
+	for (int nIteration = 0; nIteration < iterTimesTwiceScaling; nIteration++) {
 		if (conv->enable_log) {
-			std::cout << "#" << std::to_string(nIteration + 1)
-				  << " 2x scaling..." << std::endl;
+			printf("Step %02d/%02d, 2x Scaling:\n", w2x_current_step++, w2x_total_steps);
 		}
-
 		cv::Size imageSize = image.size();
 		imageSize.width *= 2;
 		imageSize.height *= 2;
@@ -1371,14 +1365,23 @@ w2xconv_convert_mat(struct W2XConv *conv,
 		fmt = w2xc::IMAGE_Y;
 	}
 	image_src.release();
-
+	
+	w2x_total_steps = 0;
+	w2x_current_step = 1;
+	int iterTimesTwiceScaling;
+	
+	if (scale != 1.0) {
+		iterTimesTwiceScaling = static_cast<int>(std::ceil(std::log2(scale)));
+		w2x_total_steps = w2x_total_steps + iterTimesTwiceScaling;
+	}
+	
 	if (denoise_level != -1) {
+		printf("Step %02d/%02d: Denoising\n", w2x_current_step++, ++w2x_total_steps);
 		apply_denoise(conv, image, denoise_level, blockSize, fmt);
 	}
 
 	if (scale != 1.0) {
 		// calculate iteration times of 2x scaling and shrink ratio which will use at last
-		int iterTimesTwiceScaling = static_cast<int>(std::ceil(std::log2(scale)));
 		double shrinkRatio = 0.0;
 		if (static_cast<int>(scale)
 		    != std::pow(2, iterTimesTwiceScaling))
@@ -1668,20 +1671,27 @@ convert_mat(struct W2XConv *conv,
 	    int blockSize,
 	    enum w2xc::image_format fmt)
 {
+	w2x_total_steps = 0;
+	w2x_current_step = 1;
+	int iterTimesTwiceScaling;
+	
+	if (scale != 1.0) {
+		iterTimesTwiceScaling = static_cast<int>(std::ceil(std::log2(scale)));
+		w2x_total_steps = w2x_total_steps + iterTimesTwiceScaling;
+	}
 	if (denoise_level != -1) {
+		printf("Step %02d/%02d: Denoising\n", w2x_current_step++, ++w2x_total_steps);
 		apply_denoise(conv, image, denoise_level, blockSize, fmt);
 	}
 
 	if (scale != 1.0) {
 		// calculate iteration times of 2x scaling and shrink ratio which will use at last
-		int iterTimesTwiceScaling = static_cast<int>(std::ceil(std::log2(scale)));
 		double shrinkRatio = 0.0;
 		if (static_cast<int>(scale)
 		    != std::pow(2, iterTimesTwiceScaling))
 		{
 			shrinkRatio = scale / std::pow(2.0, static_cast<double>(iterTimesTwiceScaling));
 		}
-
 		apply_scale(conv, image, iterTimesTwiceScaling, blockSize, fmt);
 
 		if (shrinkRatio != 0.0) {

--- a/src/w2xconv.h
+++ b/src/w2xconv.h
@@ -244,6 +244,9 @@ W2XCONV_EXPORT int w2xconv_apply_filter_y(struct W2XConv *conv,
 
 W2XCONV_EXPORT int w2xconv_test(struct W2XConv *conv, int block_size);
 
+W2XCONV_EXPORT int w2x_total_steps;
+W2XCONV_EXPORT int w2x_current_step;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Log all steps in "queue".

E.g Denoise, Scale2x*X

Example run with --scale-ratio 3:

```
Processing file [1/1] "7KMAtWE.jpg":
Step 01/03: Denoising
Processing block, column (01/03), row (01/04) ...
Iteration #1(  3-> 32)...(0.00190[ms],  238.89[GFLOPS],   19.355[GB/s])
.....
.....
Step 02/03, 2x Scaling:
Processing block, column (01/05), row (01/07) ...
Iteration #1(  3-> 32)...(0.00158[ms],  287.52[GFLOPS],   23.294[GB/s])
.....
.....
Step 03/03, 2x Scaling:
.....
.....
Done, took: 11.239s total, file: 11.239s avg: 11.239s
Finished processing 1 files
Took: 11.294secs total, filter: 7.905secs; 0 files skipped, 0 files errored. [GFLOPS: 2170.38, GFLOPS-Filter: 3100.82]

K:\w2x\waifu2x-converter-cpp\out\Release>
```

@YukihoAA Is this the correct way to handle global variables in w2x code?:

Here
https://github.com/DeadSix27/waifu2x-converter-cpp/commit/1a9ca5df702dfdde93654f5825e1396a581b64fa#diff-2a8f5272be33517914ad6fd8a68c7752R59
and here:
https://github.com/DeadSix27/waifu2x-converter-cpp/commit/1a9ca5df702dfdde93654f5825e1396a581b64fa#diff-c71cb621ea9b016b7b81067b060c2675R247
??

Please look over the whole changes, see if I made a mistake, not sure myself.
