### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -103,7 +103,7 @@ https://github.com/DeadSix27/waifu2x-converter-cpp/releases
 
 ### nVidia GPUs (CUDA):
 - Arch: `cuda`
-- Ubuntu: `?` (Submit PR if you know)
+- Ubuntu: `nvidia-cuda-toolkit`
 
 ### Building:
 ##### If you want to build for all GPU brands, just install all packages (untested, see above).


### PR DESCRIPTION
cuda is by default installed with nvidia drivers but sometimes you need to install the toolkit package to get it working.
After installing `nvidia-cuda-toolkit`, waifu2x-converter-cpp correctly compiled and usable on ubuntu server.