### PR TITLE
Catch EROFS when generating binary

### DIFF
--- a/src/modelHandler_OpenCL.cpp
+++ b/src/modelHandler_OpenCL.cpp
@@ -51,6 +51,7 @@ namespace fs = std::experimental::filesystem;
 #include <unistd.h>
 #include <sys/types.h>
 #include <pwd.h>
+#include <errno.h>
 #endif
 
 static const char prog[] =
@@ -510,7 +511,7 @@ namespace w2xc
 				if (fp == NULL)
 				{
 #if (defined __linux)
-						if (errno == 13)
+						if (errno == EACCES)
 						{
 							std::string user_folder("/tmp/.waifu2x");
 							char *home_dir = getenv ("HOME");

--- a/src/modelHandler_OpenCL.cpp
+++ b/src/modelHandler_OpenCL.cpp
@@ -543,10 +543,10 @@ namespace w2xc
 							printf("Error opening file %s: [%d] %s\n",bin_path.c_str(),errno,strerror(errno));
 							exit (EXIT_FAILURE);
 						}
-					#else
+#else
 						printf("Error opening file %s: [%d] %s\n",bin_path.c_str(),errno,strerror(errno));
 						exit (EXIT_FAILURE);
-					#endif
+#endif
 				}
 				else
 				{

--- a/src/modelHandler_OpenCL.cpp
+++ b/src/modelHandler_OpenCL.cpp
@@ -511,7 +511,7 @@ namespace w2xc
 				if (fp == NULL)
 				{
 #if (defined __linux)
-						if (errno == EACCES)
+						if (errno == EACCES || errno == EROFS)
 						{
 							std::string user_folder("/tmp/.waifu2x");
 							char *home_dir = getenv ("HOME");

--- a/src/modelHandler_OpenCL.cpp
+++ b/src/modelHandler_OpenCL.cpp
@@ -529,7 +529,7 @@ namespace w2xc
 								}
 								catch (fs::filesystem_error& e)
 								{
-									printf("ERROR: %s\n",e.what());
+									printf("Error creating directory: %s\n", e.what());
 									exit(EXIT_FAILURE);
 								}
 							}


### PR DESCRIPTION
Recover from attempt to generate binary on a read-only file system, e.g. when running on NixOS.