### PR TITLE
TTA mode support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -712,7 +712,8 @@ int main(int argc, char** argv)
 		"Generate sub folder when recursive directory is enabled.\nSet 1 to enable this. (0 or 1)", false,
 		0, "bool", cmd);
 
-	TCLAP::SwitchArg cmdTTA("", "tta", "Enable Test-Time Augmentation mode. (x8 slower, more accurate)", cmd, false);
+	TCLAP::ValueArg<bool> cmdTTA("t", "tta", "Enable Test-Time Augmentation mode. (0 or 1)", false,
+		0, "bool", cmd);
 
 	TCLAP::SwitchArg cmdQuiet("s", "silent", "Enable silent mode. (same as --log-level 1)", cmd, false);
 	

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -704,7 +704,7 @@ int main(int argc, char** argv)
 		"Search recursively through directories to find more images to process.\nIf this is set to 0 it will only check in the directory specified if the input is a directory instead of an image. (0 or 1)", false,
 		0, "bool", cmd);
 
-	TCLAP::ValueArg<bool> cmdAutoNaming("n", "auto-naming",
+	TCLAP::ValueArg<bool> cmdAutoNaming("a", "auto-naming",
 		"Add postfix to output name when output path is not specified.\nSet 0 to disable this. (0 or 1)", false,
 		1, "bool", cmd);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,7 +391,14 @@ struct ConvInfo {
 			}
 			if (convMode & CONV_SCALE)
 			{
-				postfix = postfix + _T("[x") + std::_to_tstring(scaleRatio) + _T("]");
+				_tstringstream tss;
+				tss << _T("[x") << std::fixed << std::setprecision(2) << scaleRatio << _T("]");
+				postfix = postfix + tss.str();
+			}
+			
+			if (converter->tta_mode)
+			{
+				postfix = postfix + _T("[T]");
 			}
 		};
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -705,6 +705,7 @@ int main(int argc, char** argv)
 		"Generate sub folder when recursive directory is enabled.\nSet 1 to enable this. (0 or 1)", false,
 		0, "bool", cmd);
 
+	TCLAP::SwitchArg cmdTTA("", "tta", "Enable Test-Time Augmentation mode. (x8 slower, more accurate)", cmd, false);
 
 	TCLAP::SwitchArg cmdQuiet("s", "silent", "Enable silent mode. (same as --log-level 1)", cmd, false);
 	
@@ -855,11 +856,11 @@ int main(int argc, char** argv)
 
 	if (proc != -1 && proc < num_proc)
 	{
-		converter = w2xconv_init_with_processor(proc, cmdNumberOfJobs.getValue(), log_level);
+		converter = w2xconv_init_with_processor_and_tta(proc, cmdNumberOfJobs.getValue(), log_level, cmdTTA.getValue());
 	}
 	else
 	{
-		converter = w2xconv_init(gpu, cmdNumberOfJobs.getValue(), log_level);
+		converter = w2xconv_init_with_tta(gpu, cmdNumberOfJobs.getValue(), log_level, cmdTTA.getValue());
 	}
 	
 	int jpeg_quality = 90;

--- a/src/tstring.hpp
+++ b/src/tstring.hpp
@@ -28,9 +28,11 @@
 #include "tchar.h"
 
 #if defined(_WIN32) && defined(_UNICODE)
-	typedef	std::wstring	_tstring;
+	typedef	std::wstring		_tstring;
+	typedef	std::wstringstream	_tstringstream;
 #else
-	typedef	std::string		_tstring;
+	typedef	std::string			_tstring;
+	typedef	std::stringstream	_tstringstream;
 #endif
 
 #if defined(_WIN32) && defined(_UNICODE)

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -1849,7 +1849,7 @@ void w2xconv_convert_mat
 			}
 			else
 			{
-				apply_denoise(conv, tmp, denoise_level, blockSize, fmt);
+				apply_denoise(conv, pieces[i], denoise_level, blockSize, fmt);
 			}
 		}
 		
@@ -1939,7 +1939,7 @@ void w2xconv_convert_mat
 				}
 				else
 				{
-					apply_scale(conv, tmp, 1, blockSize, fmt);
+					apply_scale(conv, pieces[i], 1, blockSize, fmt);
 				}
 				
 				/*

--- a/src/w2xconv.cpp
+++ b/src/w2xconv.cpp
@@ -1847,6 +1847,10 @@ void w2xconv_convert_mat
 				tta_mat /= 8.0;
 				pieces[i] = tta_mat.clone();
 			}
+			else
+			{
+				apply_denoise(conv, tmp, denoise_level, blockSize, fmt);
+			}
 		}
 		
 		if (pieces.size() > 1 && conv->log_level >= 2)
@@ -1932,6 +1936,10 @@ void w2xconv_convert_mat
 					}
 					tta_mat /= 8.0;
 					pieces[i] = tta_mat.clone();
+				}
+				else
+				{
+					apply_scale(conv, tmp, 1, blockSize, fmt);
 				}
 				
 				/*

--- a/src/w2xconv.h
+++ b/src/w2xconv.h
@@ -195,6 +195,7 @@ struct W2XConv
 	struct W2XConvFlopsCounter flops;
 	const struct W2XConvProcessor *target_processor;
 	int log_level;
+	bool tta_mode;
 
 	/* internal */
 	struct W2XConvImpl *impl;
@@ -212,8 +213,10 @@ W2XCONV_EXPORT	void get_png_background_colour(FILE *png_fp, bool *png_rgb, struc
 W2XCONV_EXPORT const struct W2XConvProcessor *w2xconv_get_processor_list(size_t *ret_num);
 
 W2XCONV_EXPORT struct W2XConv *w2xconv_init(enum W2XConvGPUMode gpu, int njob /* 0 = auto */, int log_level);
+W2XCONV_EXPORT struct W2XConv *w2xconv_init_with_tta(enum W2XConvGPUMode gpu, int njob /* 0 = auto */, int log_level, bool tta_mode);
 
 W2XCONV_EXPORT struct W2XConv *w2xconv_init_with_processor(int processor_idx, int njob, int log_level);
+W2XCONV_EXPORT struct W2XConv *w2xconv_init_with_processor_and_tta(int processor_idx, int njob, int log_level, bool tta_mode);
 
 /* return negative if failed */
 W2XCONV_EXPORT int w2xconv_load_models(struct W2XConv *conv, const W2XCONV_TCHAR *model_dir);


### PR DESCRIPTION
add Test-Time Augmentation mode

usage: -t (0|1) or -tta (0|1)

TTA mode is x8 slower but improve PSNR 0.15 point (more accurate)


and this PR will change --auto-naming flag from -n to -a

because -n is confusing to --noise-level

user should re-install models because w2xconv.h has changed

closes #197 