### PR TITLE
github: add basic workflow implementation

### DIFF
--- a/.github/workflows/w2x-runner.yml
+++ b/.github/workflows/w2x-runner.yml
@@ -1,0 +1,60 @@
+name: w2x-runner
+
+on:
+  pull_request:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  release:
+    types: [published, created]
+
+jobs:
+  windows-build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: cuda-dep-install
+      run: choco install cuda
+    - name: opencv-dep-install
+      run: choco install opencv
+    - name: opencl-dep-install
+      run: git clone https://github.com/KhronosGroup/OpenCL-Headers opencl
+    - name: cmake
+      run: mkdir _build && cd _build && cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_UNICODE=ON -DCMAKE_GENERATOR="Visual Studio 16 2019" -A x64 -DOPENCV_PREFIX="C:/tools/opencv/build" -DOpenCL_INCLUDE_DIR="../opencl/" -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.1"
+      shell: cmd
+    - name: msbuild
+      run: |
+        cd _build
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        msbuild waifu2xcpp.sln /p:Configuration=Release /p:Platform=x64 -m
+      shell: cmd
+    - name: upload build artifact waifu2x-converter-cpp.exe
+      uses: actions/upload-artifact@v1
+      with:
+        name: waifu2x-converter-cpp.exe
+        path: _build/out/Release/waifu2x-converter-cpp.exe
+    - name: upload build artifact w2xc.dll
+      uses: actions/upload-artifact@v1
+      with:
+        name: w2xc.dll
+        path: _build/out/Release/w2xc.dll
+  linux-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: apt-update
+      run: sudo apt update
+    - name: opencl-dep
+      run: sudo apt -y install ocl-icd-opencl-dev
+    - name: opencv-dep
+      run: sudo apt -y install libopencv-dev libopencv-imgcodecs-dev libopencv-imgproc-dev libopencv-core-dev
+    - name: run-cmake
+      run: cmake .
+    - name: build
+      run: make

--- a/.github/workflows/w2x-runner.yml
+++ b/.github/workflows/w2x-runner.yml
@@ -17,14 +17,12 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@master
-    - name: cuda-dep-install
-      run: choco install cuda
     - name: opencv-dep-install
       run: choco install opencv
     - name: opencl-dep-install
       run: git clone https://github.com/KhronosGroup/OpenCL-Headers opencl
     - name: cmake
-      run: mkdir _build && cd _build && cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_UNICODE=ON -DCMAKE_GENERATOR="Visual Studio 16 2019" -A x64 -DOPENCV_PREFIX="C:/tools/opencv/build" -DOpenCL_INCLUDE_DIR="../opencl/" -DCUDA_TOOLKIT_ROOT_DIR="C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v10.1"
+      run: mkdir _build && cd _build && cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_UNICODE=ON -DCMAKE_GENERATOR="Visual Studio 16 2019" -A x64 -DOPENCV_PREFIX="C:/tools/opencv/build" -DOpenCL_INCLUDE_DIR="../opencl/"
       shell: cmd
     - name: msbuild
       run: |

--- a/.github/workflows/w2x-runner.yml
+++ b/.github/workflows/w2x-runner.yml
@@ -8,9 +8,7 @@ on:
       - '**'
   push:
     branches:
-      - '**'
-    tags:
-      - '**'
+      - master
   release:
     types: [published, created]
 


### PR DESCRIPTION
This runner simply builds the program on Linux and a Windows and additionally uploads the windows build artifacts

This should be merged after: #207 to fix the windows build from failing.

EDIT: We should consider possibly limiting the triggers, but generally I think on every PR and every commit and every release is fine? we don't have that many PR's nor commits, so I imagine its not a big deal.

EDIT2: Also thought about disabling CUDA (on windows), it takes like 12min to install on that VM. But then again, same thing applies, we really don't have that frequent changes, so does it matter?

EDIT3: Removed cuda, since that codebase is rather stale and the aforementioned increase it check speed is totally worth it.