### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -95,7 +95,7 @@ https://github.com/DeadSix27/waifu2x-converter-cpp/releases
    
 #### AMD GPUs:
 - Arch: `opencl-mesa`
-- Ubuntu: `mesa-opencl-icd opencl-headers`
+- Ubuntu: `mesa-opencl-icd opencl-headers opencl-dev`
 
 #### nVidia GPUs:
 - Arch: `opencl-nvidia opencl-headers ocl-icd`

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -95,7 +95,7 @@ https://github.com/DeadSix27/waifu2x-converter-cpp/releases
    
 #### AMD GPUs:
 - Arch: `opencl-mesa`
-- Ubuntu: `mesa-opencl-icd opencl-headers opencl-dev`
+- Ubuntu: `mesa-opencl-icd opencl-headers ocl-icd-opencl-dev`
 
 #### nVidia GPUs:
 - Arch: `opencl-nvidia opencl-headers ocl-icd`


### PR DESCRIPTION
On Ubuntu 19.10 + AMD ATI Radeon HD 6770, `cmake ..` failed without `opencl-dev`(`ocl-icd-opencl-dev`) package.

```bash
nnn1590@ubuntu:~/Documents/waifu2x-converter-cpp/out$ cmake ..
-- Found git, set version to: v5.3.3 (master-b45498b)
-- System is: Linux (Linux)
CMake Error at /usr/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Could NOT find OpenCL (missing: OpenCL_LIBRARY) (found version "2.2")
Call Stack (most recent call first):
  /usr/share/cmake-3.13/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.13/Modules/FindOpenCL.cmake:149 (find_package_handle_standard_args)
  CMakeLists.txt:102 (FIND_PACKAGE)


-- Configuring incomplete, errors occurred!
See also "/home/nnn1590/Documents/waifu2x-converter-cpp/out/CMakeFiles/CMakeOutput.log".
```