### PR TITLE
Simplify AltiVec detection and support FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64" OR
 	set(X86_TRUE true)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch|^arm")
 	set(ARM_TRUE true)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc|^powerpc")
 	set(PPC_TRUE true)
 else()
 	set(X86_TRUE false)
@@ -272,36 +272,8 @@ endif()
 
 option(PPCOPT "Enable PowerPC SIMD optimizations" ${PPC_TRUE})
 if(PPCOPT)
-	include("CheckCSourceRuns")
-
-	check_c_source_runs("
-		#include <sys/auxv.h>
-		int main(void) {
-			return 0;
-		}" HAVE_AUXV)
-
-	set(CMAKE_REQUIRED_FLAGS -maltivec)
-
-	check_c_source_runs("
-		#include <altivec.h>
-		int main(void) {
-			__vector int vi = { 0, 0, 0, 0 };
-			int i[4];
-			vec_st(vi, 0, i);
-			return i[0];
-		}" HAVE_ALTIVEC)
-
-	unset(CMAKE_REQUIRED_FLAGS)
-
-	if(HAVE_AUXV)
-		add_definitions(-DPPCOPT -DHAVE_AUXV)
-		set(OPT_SOURCES src/modelHandler_altivec.cpp)
-	elseif(HAVE_ALTIVEC)
-		add_definitions(-DPPCOPT)
-		set(OPT_SOURCES src/modelHandler_altivec.cpp)
-	else()
-		message(STATUS "AltiVec not found. disabled.")
-	endif()
+	add_definitions(-DPPCOPT)
+	set(OPT_SOURCES src/modelHandler_altivec.cpp)
 endif()
 
 add_library(w2xc SHARED


### PR DESCRIPTION
Tested on FreeBSD aarch64, armv6.

- FreeBSD 12.0+ has a `getauxval` copycat since https://github.com/freebsd/freebsd/commit/990c7fb0441b
- GCC 5 supports `__has_include`, so simplify `<sys/auxv.h>` detection
- Assume AltiVec via builtin macro instead of `check_c_source_runs` to simplify and support cross-compilation
- `getauxval` always returns `unsigned long`, even on ARM
- Unexpand `HWCAP_ALTIVEC` to a proper macro for consistency with ARM code
- FreeBSD has `HWCAP_NEON` but not `HWCAP_ARM_NEON`
