### PR TITLE
Fix GCC 10 compile errors

### DIFF
--- a/src/threadPool.cpp
+++ b/src/threadPool.cpp
@@ -21,6 +21,9 @@
 * SOFTWARE.
 */
 
+#if defined __linux
+#include <stdio.h>
+#endif
 #include <thread>
 #include <atomic>
 #include "threadPool.hpp"
@@ -82,7 +85,6 @@ namespace w2xc
 
 #include <unistd.h>
 #include <sys/eventfd.h>
-#include <stdio.h>
 
 	int create_event()
 	{

--- a/src/threadPool.cpp
+++ b/src/threadPool.cpp
@@ -82,6 +82,7 @@ namespace w2xc
 
 #include <unistd.h>
 #include <sys/eventfd.h>
+#include <stdio.h>
 
 	int create_event()
 	{


### PR DESCRIPTION
Fixed issue #240 by adding stdio.h include headers to src/threadPool.cpp

