### PR TITLE
Cuda 11 fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,21 +377,35 @@ if(CUDA_FOUND)
             COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_20 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx20 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
             DEPENDS src/modelHandler_CUDA.cu
         )
-    endif()
-    add_custom_command(
-        OUTPUT modelHandler_CUDA.ptx30.h
-        COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 conv
+	endif()
+	if (CUDA_VERSION_MAJOR LESS 10)
+		add_custom_command(
+			OUTPUT modelHandler_CUDA.ptx30.h
+			COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
+			DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 conv
+		)
+		add_custom_command(
+			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30
+			COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_30 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+			DEPENDS src/modelHandler_CUDA.cu
+		)
+	endif()
+	add_custom_command(
+        OUTPUT modelHandler_CUDA.ptx53.h
+        COMMAND ${CONV_EXE} modelHandler_CUDA.ptx53 modelHandler_CUDA.ptx53.h str
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx53 conv
     )
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30
-        COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_30 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx30 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx53
+        COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_53 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx53 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
         DEPENDS src/modelHandler_CUDA.cu
     )
     if (CUDA_VERSION_MAJOR LESS 9)
         set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
-    else()
-        set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h)
+	elseif (CUDA_VERSION_MAJOR LESS 10)
+		set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h)
+	else()
+		set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx53.h)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,7 +378,7 @@ if(CUDA_FOUND)
             DEPENDS src/modelHandler_CUDA.cu
         )
 	endif()
-	if (CUDA_VERSION_MAJOR LESS 10)
+	if (CUDA_VERSION_MAJOR LESS 11)
 		add_custom_command(
 			OUTPUT modelHandler_CUDA.ptx30.h
 			COMMAND ${CONV_EXE} modelHandler_CUDA.ptx30 modelHandler_CUDA.ptx30.h str
@@ -391,21 +391,21 @@ if(CUDA_FOUND)
 		)
 	endif()
 	add_custom_command(
-        OUTPUT modelHandler_CUDA.ptx53.h
-        COMMAND ${CONV_EXE} modelHandler_CUDA.ptx53 modelHandler_CUDA.ptx53.h str
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx53 conv
+        OUTPUT modelHandler_CUDA.ptx52.h
+        COMMAND ${CONV_EXE} modelHandler_CUDA.ptx52 modelHandler_CUDA.ptx52.h str
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx52 conv
     )
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx53
-        COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_53 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx53 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx52
+        COMMAND ${CUDA_NVCC_EXECUTABLE} ${CUDA_NVCC_FLAGS} -arch=sm_52 -ptx -o ${CMAKE_CURRENT_BINARY_DIR}/modelHandler_CUDA.ptx52 ${CMAKE_CURRENT_SOURCE_DIR}/src/modelHandler_CUDA.cu
         DEPENDS src/modelHandler_CUDA.cu
     )
     if (CUDA_VERSION_MAJOR LESS 9)
-        set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
-	elseif (CUDA_VERSION_MAJOR LESS 10)
-		set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx30.h)
+        set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx52.h modelHandler_CUDA.ptx30.h modelHandler_CUDA.ptx20.h)
+	elseif (CUDA_VERSION_MAJOR LESS 11)
+		set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx52.h modelHandler_CUDA.ptx30.h)
 	else()
-		set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx53.h)
+		set(GPU_CODE ${GPU_CODE} modelHandler_CUDA.ptx52.h)
     endif()
 endif()
 

--- a/src/modelHandler_CUDA.cpp
+++ b/src/modelHandler_CUDA.cpp
@@ -48,8 +48,13 @@ static void *handle;
             #include "modelHandler_CUDA.ptx20.h"
             ;
     #endif // CUDART_VERSION < 9000
+	#if CUDART_VERSION < 10000
     static const char prog30[] =
         #include "modelHandler_CUDA.ptx30.h"
+	;
+	#endif // CUDART_VERSION < 10000
+	static const char prog53[] =
+        #include "modelHandler_CUDA.ptx53.h"
 	;
 #endif // HAVE_CUDA
 
@@ -172,9 +177,14 @@ namespace w2xc
 			return false;
 		}
 
-		const char *prog = prog30;
+		const char *prog = prog53;
 		// cuda 9.0 doesn't support Compute 20
-
+#if CUDART_VERSION < 10000
+		if (cap_major < 3)
+		{
+			prog = prog30;
+		}
+#endif // CUDART_VERSION < 10000
 #if CUDART_VERSION < 9000
 		if (cap_major < 3)
 		{

--- a/src/modelHandler_CUDA.cpp
+++ b/src/modelHandler_CUDA.cpp
@@ -47,14 +47,15 @@ static void *handle;
         static const char prog20[] =
             #include "modelHandler_CUDA.ptx20.h"
             ;
-    #endif // CUDART_VERSION < 9000
-	#if CUDART_VERSION < 10000
+	#endif
+	// Cuda 11.0+ doesn't support Compute 3.0
+	#if CUDART_VERSION < 11000
     static const char prog30[] =
         #include "modelHandler_CUDA.ptx30.h"
 	;
-	#endif // CUDART_VERSION < 10000
-	static const char prog53[] =
-        #include "modelHandler_CUDA.ptx53.h"
+	#endif
+	static const char prog52[] =
+        #include "modelHandler_CUDA.ptx52.h"
 	;
 #endif // HAVE_CUDA
 
@@ -177,20 +178,22 @@ namespace w2xc
 			return false;
 		}
 
-		const char *prog = prog53;
-		// cuda 9.0 doesn't support Compute 20
-#if CUDART_VERSION < 10000
-		if (cap_major < 3)
+		const char *prog = prog52;
+		// cuda 11.0+ doesn't support Compute 3.0
+#if CUDART_VERSION < 11000
+		if (cap_major < 5)
 		{
 			prog = prog30;
 		}
-#endif // CUDART_VERSION < 10000
+#endif
+		// cuda 9.0+ doesn't support Compute 2.0
 #if CUDART_VERSION < 9000
 		if (cap_major < 3)
 		{
 			prog = prog20;
+			
 		}
-#endif // CUDART_VERSION < 9000
+#endif
 
 		r = cuStreamCreate(&stream, 0);
 


### PR DESCRIPTION
Cuda 11 compile patch as suggested in issue #250 using sm_53 instead of sm_30 when Cuda 10 and up is detected.