### PR TITLE
Fix symbol conflict in picojson.h with GCC 11 internal macro

### DIFF
--- a/include/picojson.h
+++ b/include/picojson.h
@@ -194,8 +194,8 @@ public:
 private:
   template <typename T> value(const T *); // intentionally defined to block implicit conversion of pointer to bool
   template <typename Iter> static void _indent(Iter os, int indent);
-  template <typename Iter> void _serialize(Iter os, int indent) const;
-  std::string _serialize(int indent) const;
+  template <typename Iter> void serialize_(Iter os, int indent) const;
+  std::string serialize_(int indent) const;
   void clear();
 };
 
@@ -557,11 +557,11 @@ template <typename Iter> void serialize_str(const std::string &s, Iter oi) {
 }
 
 template <typename Iter> void value::serialize(Iter oi, bool prettify) const {
-  return _serialize(oi, prettify ? 0 : -1);
+  return serialize_(oi, prettify ? 0 : -1);
 }
 
 inline std::string value::serialize(bool prettify) const {
-  return _serialize(prettify ? 0 : -1);
+  return serialize_(prettify ? 0 : -1);
 }
 
 template <typename Iter> void value::_indent(Iter oi, int indent) {
@@ -571,7 +571,7 @@ template <typename Iter> void value::_indent(Iter oi, int indent) {
   }
 }
 
-template <typename Iter> void value::_serialize(Iter oi, int indent) const {
+template <typename Iter> void value::serialize_(Iter oi, int indent) const {
   switch (type_) {
   case string_type:
     serialize_str(*u_.string_, oi);
@@ -588,7 +588,7 @@ template <typename Iter> void value::_serialize(Iter oi, int indent) const {
       if (indent != -1) {
         _indent(oi, indent);
       }
-      i->_serialize(oi, indent);
+      i->serialize_(oi, indent);
     }
     if (indent != -1) {
       --indent;
@@ -616,7 +616,7 @@ template <typename Iter> void value::_serialize(Iter oi, int indent) const {
       if (indent != -1) {
         *oi++ = ' ';
       }
-      i->second._serialize(oi, indent);
+      i->second.serialize_(oi, indent);
     }
     if (indent != -1) {
       --indent;
@@ -636,9 +636,9 @@ template <typename Iter> void value::_serialize(Iter oi, int indent) const {
   }
 }
 
-inline std::string value::_serialize(int indent) const {
+inline std::string value::serialize_(int indent) const {
   std::string s;
-  _serialize(std::back_inserter(s), indent);
+  serialize_(std::back_inserter(s), indent);
   return s;
 }
 


### PR DESCRIPTION
[x86: Define _serialize as macro](https://patchwork.ozlabs.org/project/gcc/patch/CAMe9rOp_DLg55kRxw2v75PPeqj-8tDKob5z-+EWPpf-L3OuKKw@mail.gmail.com/)

gcc --version (from archlinux official repository)

```
gcc (GCC) 11.2.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Error log

```
[ 60%] Building CXX object CMakeFiles/w2xc.dir/src/w2xconv.cpp.o
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:197:63: error: macro "_serialize" passed 2 arguments, but takes just 0
  197 |   template <typename Iter> void _serialize(Iter os, int indent) const;
      |                                                               ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:198:36: error: macro "_serialize" passed 1 arguments, but takes just 0
  198 |   std::string _serialize(int indent) const;
      |                                    ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:560:42: error: macro "_serialize" passed 2 arguments, but takes just 0
  560 |   return _serialize(oi, prettify ? 0 : -1);
      |                                          ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:564:38: error: macro "_serialize" passed 1 arguments, but takes just 0
  564 |   return _serialize(prettify ? 0 : -1);
      |                                      ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:574:68: error: macro "_serialize" passed 2 arguments, but takes just 0
  574 | template <typename Iter> void value::_serialize(Iter oi, int indent) const {
      |                                                                    ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:591:31: error: macro "_serialize" passed 2 arguments, but takes just 0
  591 |       i->_serialize(oi, indent);
      |                               ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:619:38: error: macro "_serialize" passed 2 arguments, but takes just 0
  619 |       i->second._serialize(oi, indent);
      |                                      ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:639:48: error: macro "_serialize" passed 1 arguments, but takes just 0
  639 | inline std::string value::_serialize(int indent) const {
      |                                                ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:641:43: error: macro "_serialize" passed 2 arguments, but takes just 0
  641 |   _serialize(std::back_inserter(s), indent);
      |                                           ^
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/x86gprintrin.h:71,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/immintrin.h:27,
                 from /opt/cuda/include/CL/cl_platform.h:495,
                 from /opt/cuda/include/CL/cl.h:23,
                 from /opt/cuda/include/CL/opencl.h:30,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/CLlib.h:37,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/Buffer.hpp:61,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/include/serializeintrin.h:37: note: macro "_serialize" defined here
   37 | #define _serialize()    __builtin_ia32_serialize ()
      | 
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:197:65: error: expected initializer before 'const'
  197 |   template <typename Iter> void _serialize(Iter os, int indent) const;
      |                                                                 ^~~~~
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:198:15: error: expected ';' at end of member declaration
  198 |   std::string _serialize(int indent) const;
      |               ^~~~~~~~~~
      |                         ;
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:198:38: error: declaration does not declare anything [-fpermissive]
  198 |   std::string _serialize(int indent) const;
      |                                      ^~~~~
[ 65%] Building CXX object CMakeFiles/w2xc.dir/src/common.cpp.o
In file included from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/modelHandler.hpp:31,
                 from /tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/src/w2xconv.cpp:39:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h: In member function 'void picojson::value::serialize(Iter, bool) const':
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:560:10: error: return-statement with a value, in function returning 'void' [-fpermissive]
  560 |   return _serialize(oi, prettify ? 0 : -1);
      |          ^~~~~~~~~~
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h: At global scope:
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:574:70: error: expected initializer before 'const'
  574 | template <typename Iter> void value::_serialize(Iter oi, int indent) const {
      |                                                                      ^~~~~
/tmp/makepkg/waifu2x-converter-cpp-cuda-git/src/waifu2x-converter-cpp/include/picojson.h:639:50: error: expected initializer before 'const'
  639 | inline std::string value::_serialize(int indent) const {
      |                                                  ^~~~~
[ 69%] Building CXX object CMakeFiles/w2xc.dir/src/cvwrap.cpp.o
[ 73%] Building CXX object CMakeFiles/w2xc.dir/src/Env.cpp.o
[ 78%] Building CXX object CMakeFiles/w2xc.dir/src/Buffer.cpp.o
[ 82%] Building CXX object CMakeFiles/w2xc.dir/src/tstring.cpp.o
make[2]: *** [CMakeFiles/w2xc.dir/build.make:188: CMakeFiles/w2xc.dir/src/w2xconv.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```